### PR TITLE
Use a uid@provider syntax

### DIFF
--- a/src/SiteMaster/Core/Registry/Query.php
+++ b/src/SiteMaster/Core/Registry/Query.php
@@ -99,13 +99,13 @@ class Query extends \IteratorIterator
      */
     public function getByUser($query)
     {
-        $details = explode('?', $query);
+        $details = explode('@', $query);
         
         if (count($details) != 2) {
-            throw new InvalidArgumentException('Must provide a query in the format of provider?uid');
+            throw new InvalidArgumentException('Must provide a query in the format of uid@provider');
         }
         
-        if (!$user = User::getByUIDAndProvider($details[1], $details[0])) {
+        if (!$user = User::getByUIDAndProvider($details[0], $details[1])) {
             return array();
         }
         

--- a/tests/SiteMaster/Core/Registry/QueryDBTest.php
+++ b/tests/SiteMaster/Core/Registry/QueryDBTest.php
@@ -14,7 +14,7 @@ class QueryDBTest extends DBTestCase
         $this->setUpDB();
         
         $query = new Query();
-        $result = $query->query('test?2');
+        $result = $query->query('2@test');
         $sites = array();
         
         foreach ($result as $site) {
@@ -26,9 +26,9 @@ class QueryDBTest extends DBTestCase
             'http://www.test.com/test/'
         );
         
-        $this->assertEquals($expected, $sites, 'test?2 should have 2 accepted sites');
+        $this->assertEquals($expected, $sites, '2@test should have 2 accepted sites');
 
-        $result = $query->query('test?1');
+        $result = $query->query('1@test');
         $sites = array();
 
         foreach ($result as $site) {
@@ -41,7 +41,7 @@ class QueryDBTest extends DBTestCase
             'http://www.test.com/test/',
         );
 
-        $this->assertEquals($expected, $sites, 'test?1 should have 2 accepted sites');
+        $this->assertEquals($expected, $sites, '1@test should have 2 accepted sites');
     }
 
     /**

--- a/tests/SiteMaster/Core/Registry/QueryTest.php
+++ b/tests/SiteMaster/Core/Registry/QueryTest.php
@@ -15,7 +15,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(Query::QUERY_TYPE_URL, $query->getQueryType('http://www.domain.com/test/test.php?query#fragment'));
         $this->assertEquals(Query::QUERY_TYPE_URL, $query->getQueryType('http://www.domain.com'));
 
-        $this->assertEquals(Query::QUERY_TYPE_USER, $query->getQueryType('provider?uid'));
+        $this->assertEquals(Query::QUERY_TYPE_USER, $query->getQueryType('uid@provider'));
         $this->assertEquals(Query::QUERY_TYPE_USER, $query->getQueryType('test'), 'should fall back to a user');
 
         $this->assertEquals(Query::QUERY_TYPE_ALL, $query->getQueryType('*'));

--- a/www/templates/html/SiteMaster/Core/Registry/Search.tpl.php
+++ b/www/templates/html/SiteMaster/Core/Registry/Search.tpl.php
@@ -12,7 +12,7 @@ foreach ($authPlugins as $plugin) {
         Examples:
         <ul>
             <li>Site: absolute URI, must include protocol (http://wwww.domain.com/)</li>
-            <li>Person: provider:uid (google?1111)
+            <li>Person: uid@provider (1111@UNL)
                 <p>Available providers are: <?php echo implode(', ', $providers); ?></p>
             </li>
         </ul>


### PR DESCRIPTION
provider?uid was confusing.  uid@provider is more common and is more readable
