### PR TITLE
Add Support for help text stored as markdown files

### DIFF
--- a/src/SiteMaster/Core/Auditor/Metric/Mark.php
+++ b/src/SiteMaster/Core/Auditor/Metric/Mark.php
@@ -2,6 +2,8 @@
 namespace SiteMaster\Core\Auditor\Metric;
 
 use DB\Record;
+use SiteMaster\Core\Auditor\Metric;
+use SiteMaster\Core\Auditor\MetricInterface;
 use SiteMaster\Core\Registry\Site\Member;
 
 class Mark extends Record
@@ -59,5 +61,43 @@ class Mark extends Record
         }
         
         return $scan;
+    }
+
+    /**
+     * Get the metric for this mark
+     * 
+     * @return bool|MetricInterface
+     */
+    public function getMetric()
+    {
+        $metric_record = Metric::getByID($this->metrics_id);
+        
+        if (!$metric_plugin = $metric_record->getMetricObject()) {
+            return false;
+        }
+        
+        return $metric_plugin;
+    }
+
+    /**
+     * Get the help file for this mark
+     * 
+     * @return bool|string
+     */
+    public function getHelpText()
+    {
+        if (!$metric_plugin = $this->getMetric()) {
+            return false;
+        }
+        
+        $plugin = $metric_plugin->getPlugin();
+
+        $file_path = $plugin->getRootDirectory() . '/help_text/' . $this->machine_name . '.md';
+
+        if (file_exists($file_path)) {
+            return file_get_contents($file_path);
+        }
+
+        return false;
     }
 }

--- a/www/css/core.css
+++ b/www/css/core.css
@@ -394,7 +394,6 @@ Notices
 pre, code {
     font-family: "Courier New", Courier, monospace;
     margin-bottom: 10px;
-    background-color: #EEE;
     overflow: auto;
     padding: 1em;
     word-wrap: break-word;
@@ -428,4 +427,8 @@ code {
 }
 .sitemaster_core_admin_allsites table tr td:first-child {
     word-wrap: break-word;
+}
+
+.machine_name {
+    font-size: .5em;
 }

--- a/www/templates/html/SiteMaster/Core/Auditor/Site/Page/Mark/View.tpl.php
+++ b/www/templates/html/SiteMaster/Core/Auditor/Site/Page/Mark/View.tpl.php
@@ -31,10 +31,21 @@
     <?php
     }
 
-    if (!empty($context->mark->help_text)) {
+    $help_text = $context->mark->getRawObject()->getHelpText();
+    if (!empty($context->mark->help_text) || !empty($help_text)) {
         ?>
         <dt>Suggested Fix</dt>
-        <dd><?php echo \Michelf\MarkdownExtra::defaultTransform($context->mark->help_text) ?></dd>
+        <dd>
+            <?php 
+            if (!empty($context->mark->help_text)) {
+                echo \Michelf\MarkdownExtra::defaultTransform($context->mark->help_text);
+            }
+
+            if (!empty($help_text)) {
+                echo \Michelf\MarkdownExtra::defaultTransform($help_text);
+            }
+            ?>
+        </dd>
     <?php
     }
 
@@ -59,3 +70,7 @@
 </dl>
 
 <a href="<?php echo $context->page->getURL() ?>">Go back to the page report</a>
+
+<div class="pull-right wdn-pull-right">
+    <span class="machine_name">Machine Name: <?php echo $context->mark->machine_name ?></span>
+</div>


### PR DESCRIPTION
Hopefully, this will allow better collaboration and editing of the help text.

I'm leaving the old help text available for use, which is a field stored in the database on the `mark` record.  That field will be good for code-generated help text, such as what we are doing here: https://github.com/UNLSiteMaster/metric_pa11y/blob/master/src/Metric.php#L118

The markdown help text option is there to offer better hand-written help text.