### PR TITLE
Impriove Queue position that is reported to users

### DIFF
--- a/src/SiteMaster/Core/Auditor/Scan/Progress.php
+++ b/src/SiteMaster/Core/Auditor/Scan/Progress.php
@@ -2,7 +2,7 @@
 namespace SiteMaster\Core\Auditor\Scan;
 
 use SiteMaster\Core\Auditor\Site\Page;
-use SiteMaster\Core\Auditor\scans\Queued;
+use SiteMaster\Core\Auditor\Scans\Queued;
 use SiteMaster\Core\Registry\Site;
 use SiteMaster\Core\ViewableInterface;
 use SiteMaster\Core\InvalidArgumentException;

--- a/src/SiteMaster/Core/Auditor/Scan/Progress.php
+++ b/src/SiteMaster/Core/Auditor/Scan/Progress.php
@@ -63,6 +63,6 @@ class Progress extends View
 
         $queue = new Queued(array('limit'=>-1));
         
-        return array_search($this->scan->id, $queue->getInnerIterator()->getArrayCopy());
+        return $queue->getPositionOfScan($this->scan);
     }
 }

--- a/src/SiteMaster/Core/Auditor/Scan/Progress.php
+++ b/src/SiteMaster/Core/Auditor/Scan/Progress.php
@@ -61,7 +61,7 @@ class Progress extends View
             return false;
         }
 
-        $queue = new Queued(array('limit'=>-1));
+        $queue = new Queued();
         
         return $queue->getPositionOfScan($this->scan);
     }

--- a/src/SiteMaster/Core/Auditor/Scan/Progress.php
+++ b/src/SiteMaster/Core/Auditor/Scan/Progress.php
@@ -2,7 +2,7 @@
 namespace SiteMaster\Core\Auditor\Scan;
 
 use SiteMaster\Core\Auditor\Site\Page;
-use SiteMaster\Core\Auditor\Site\Pages\Queued;
+use SiteMaster\Core\Auditor\scans\Queued;
 use SiteMaster\Core\Registry\Site;
 use SiteMaster\Core\ViewableInterface;
 use SiteMaster\Core\InvalidArgumentException;
@@ -61,14 +61,8 @@ class Progress extends View
             return false;
         }
 
-        $site = $this->scan->getSite();
-        
-        if (!$homepage = Page::getByScanIDAndURI($this->scan->id, $site->base_url)) {
-            return false;
-        }
-
         $queue = new Queued(array('limit'=>-1));
         
-        return array_search($homepage->id, $queue->getInnerIterator()->getArrayCopy());
+        return array_search($this->scan->id, $queue->getInnerIterator()->getArrayCopy());
     }
 }

--- a/src/SiteMaster/Core/Auditor/Scans/Queued.php
+++ b/src/SiteMaster/Core/Auditor/Scans/Queued.php
@@ -1,0 +1,48 @@
+<?php
+namespace SiteMaster\Core\Auditor\Scans;
+
+/**
+ * This class will compile a list of all scans that are queued, in the order in which they will be processed.
+ * 
+ * Class Queued
+ * @package SiteMaster\Core\Auditor\Scans
+ */
+class Queued extends All
+{
+    public function __construct(array $options = array())
+    {
+        parent::__construct($options);
+    }
+
+    public function getSQL()
+    {
+        //Build the list
+        $sql = "SELECT scans.id as id
+                FROM scanned_page
+                LEFT JOIN scans ON (scanned_page.scans_id = scans.id)
+                WHERE scans.status = 'QUEUED'
+                GROUP BY scans.id
+                ORDER BY scanned_page.priority ASC, scanned_page.date_created ASC";
+
+        return $sql;
+    }
+
+    public function getLimit()
+    {
+        if (isset($this->options['limit'])) {
+            if ($this->options['limit'] == '-1') {
+                //Don't use a limit
+                return '';
+            }
+            return 'LIMIT ' . (int)$this->options['limit'];
+        }
+
+        //default to 1
+        return 'LIMIT 1';
+    }
+
+    public function getOrderBy()
+    {
+        return 'ORDER BY priority ASC, start_time ASC';
+    }
+}

--- a/src/SiteMaster/Core/Auditor/Scans/Queued.php
+++ b/src/SiteMaster/Core/Auditor/Scans/Queued.php
@@ -19,13 +19,13 @@ class Queued extends All
     public function getSQL()
     {
         //Build the list
-        $sql = "SELECT scans.id as id, MIN(scanned_page.priority) as priority, MIN(scanned_page.date_created) as date_created
+        $sql = "SELECT scans.id as id
                 FROM scanned_page
                 LEFT JOIN scans ON (scanned_page.scans_id = scans.id)
                 WHERE scans.status = '" . Scan::STATUS_QUEUED . "'
                     AND scanned_page.status = '" . Page::STATUS_QUEUED ."'
                 GROUP BY scans.id
-                ORDER BY priority ASC, date_created ASC";
+                ORDER BY MIN(scanned_page.priority) ASC, MIN(scanned_page.date_created) ASC";
 
         return $sql;
     }

--- a/src/SiteMaster/Core/Auditor/Scans/Queued.php
+++ b/src/SiteMaster/Core/Auditor/Scans/Queued.php
@@ -1,5 +1,7 @@
 <?php
 namespace SiteMaster\Core\Auditor\Scans;
+use SiteMaster\Core\Auditor\Scan;
+use SiteMaster\Core\Auditor\Site\Page;
 
 /**
  * This class will compile a list of all scans that are queued, in the order in which they will be processed.
@@ -17,12 +19,13 @@ class Queued extends All
     public function getSQL()
     {
         //Build the list
-        $sql = "SELECT scans.id as id
+        $sql = "SELECT scans.id as id, MIN(scanned_page.priority) as priority, MIN(scanned_page.date_created) as date_created
                 FROM scanned_page
                 LEFT JOIN scans ON (scanned_page.scans_id = scans.id)
-                WHERE scans.status = 'QUEUED'
+                WHERE scans.status = '" . Scan::STATUS_QUEUED . "'
+                    AND scanned_page.status = '" . Page::STATUS_QUEUED ."'
                 GROUP BY scans.id
-                ORDER BY scanned_page.priority ASC, scanned_page.date_created ASC";
+                ORDER BY priority ASC, date_created ASC";
 
         return $sql;
     }

--- a/src/SiteMaster/Core/Auditor/Scans/Queued.php
+++ b/src/SiteMaster/Core/Auditor/Scans/Queued.php
@@ -29,4 +29,15 @@ class Queued extends All
 
         return $sql;
     }
+
+    /**
+     * Get the position in the queue for a given scan
+     * 
+     * @param Scan $scan
+     * @return mixed
+     */
+    public function getPositionOfScan(\SiteMaster\Core\Auditor\Scan $scan)
+    {
+        return array_search($scan->id, $this->getInnerIterator()->getArrayCopy());
+    }
 }

--- a/src/SiteMaster/Core/Auditor/Scans/Queued.php
+++ b/src/SiteMaster/Core/Auditor/Scans/Queued.php
@@ -26,23 +26,4 @@ class Queued extends All
 
         return $sql;
     }
-
-    public function getLimit()
-    {
-        if (isset($this->options['limit'])) {
-            if ($this->options['limit'] == '-1') {
-                //Don't use a limit
-                return '';
-            }
-            return 'LIMIT ' . (int)$this->options['limit'];
-        }
-
-        //default to 1
-        return 'LIMIT 1';
-    }
-
-    public function getOrderBy()
-    {
-        return 'ORDER BY priority ASC, start_time ASC';
-    }
 }

--- a/src/SiteMaster/Core/Auditor/Site/Pages/Queued.php
+++ b/src/SiteMaster/Core/Auditor/Site/Pages/Queued.php
@@ -35,6 +35,6 @@ class Queued extends All
 
     public function getOrderBy()
     {
-        return 'ORDER BY priority ASC, start_time ASC';
+        return 'ORDER BY priority ASC, date_created ASC';
     }
 }


### PR DESCRIPTION
This changes the reported queue position so that it reflects the number of scans in queue rather than the number of pages in queue.

Reporting the number of pages in queue was causing two main problems:

1. people didn't realize that the position was in terms of pages
2. the value kept raising and falling as sites were being spidered and added to the queue.