### PR TITLE
Decode html5 entities before processing a document

### DIFF
--- a/src/SiteMaster/Core/Auditor/Parser/HTML5.php
+++ b/src/SiteMaster/Core/Auditor/Parser/HTML5.php
@@ -20,6 +20,8 @@ class HTML5 extends \Spider_Parser
         $document = new \DOMDocument();
         $document->strictErrorChecking = false;
 
+        $content = html_entity_decode($content, ENT_HTML5);
+
         if ($this->options['tidy'] && extension_loaded('tidy')) {
             //Convert and repair as xhtml
             $tidy     = new \tidy;


### PR DESCRIPTION
In html5 it is possible for links to look like this: https&colon;&sol;&sol;bulletin&period;unl&period;edu&sol;undergraduate&sol;