### PR TITLE
Ensure that html5 encoded links are decoded correctly

### DIFF
--- a/src/SiteMaster/Core/Auditor/Parser/HTML5.php
+++ b/src/SiteMaster/Core/Auditor/Parser/HTML5.php
@@ -13,8 +13,6 @@ class HTML5 extends \Spider_Parser
         $document = new \DOMDocument();
         $document->strictErrorChecking = false;
 
-        $content = html_entity_decode($content, ENT_HTML5);
-
         if (function_exists('mb_convert_encoding')) {
             //Ensure content is UTF-8, if it isn't, loadXML might not work.
             $content = mb_convert_encoding($content, 'UTF-8');

--- a/tests/SiteMaster/Core/Auditor/Parser/HTML5Test.php
+++ b/tests/SiteMaster/Core/Auditor/Parser/HTML5Test.php
@@ -1,0 +1,35 @@
+<?php
+namespace SiteMaster\Core\Auditor\Parser;
+
+use SiteMaster\Core\Util;
+
+class HTML5Test extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function testHtml5EncodedLinks()
+    {
+        $parser = new HTML5();
+        $html = file_get_contents(Util::getRootDir() . '/tests/data/html5links.html');
+        $xpath = $parser->parse($html);
+        
+        $nodes = $xpath->query(
+            "//xhtml:a[@href]/@href | //a[@href]/@href"
+        );
+        
+        $urls = [];
+        foreach ($nodes as $node) {
+            $urls[] = $node->nodeValue;
+        }
+        
+        $expected = [
+            'https://bulletin.unl.edu/undergraduate/',
+            'https://bulletin.unl.edu/undergraduate/',
+            'https://bulletin.unl.edu/undergraduate/?u=http%3A%2F%2Fexample.com%2Ftest%0D%0A',
+            'https://bulletin.unl.edu/undergraduate/?u=http%3A%2F%2Fexample.com%2Ftest%0D%0A',
+        ];
+
+        $this->assertEquals($expected, $urls, 'URLs should be decoded correctly');
+    }
+}

--- a/tests/data/html5links.html
+++ b/tests/data/html5links.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+    <title>SiteMaster testing site</title>
+</head>
+<body>
+<div>
+    This site just contains a few pages to help with integration testing of SiteMaster
+    <a href="https://bulletin.unl.edu/undergraduate/">Regular link</a>
+    <a href="https&colon;&sol;&sol;bulletin&period;unl&period;edu&sol;undergraduate&sol;">html5 encoded link</a>
+    <a href="https://bulletin.unl.edu/undergraduate/?u=http%3A%2F%2Fexample.com%2Ftest%0D%0A">Regular link with a url as a parameter</a>
+    <a href="https&colon;&sol;&sol;bulletin&period;unl&period;edu&sol;undergraduate&sol;&quest;u&equals;http&percnt;3A&percnt;2F&percnt;2Fexample&period;com&percnt;2Ftest&percnt;0D&percnt;0A">html5 encoded with a param</a>
+    <pre><code>&lt;a class=&quot;retina&quot; href=&quot;https://example.com/should-not-be-found&quot;&gt;Retina&lt;/a&gt;</code></pre>
+</div>
+</body>
+</html>


### PR DESCRIPTION
And prevent decoding ALL THE THINGS.  Also, added some tests which I should have done earlier.

It looks like the new html5 parser already handles this.

I should mention blindly decoding the entire page was having unintended consequences, such as turning example code into real code.