### PR TITLE
Add central phantomjs support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ data/database.mwb.bak
 /beanstalk_console
 /wdn
 /scripts/sitemaster_phantom_complied.js
+/scripts/sitemaster_phantom_complied_test.js

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ data/database.mwb.bak
 /tests/report
 /.vagrant
 /beanstalk_console
+/wdn
+/scripts/sitemaster_phantom_complied.js

--- a/data/compilePhantomjsScript.js.php
+++ b/data/compilePhantomjsScript.js.php
@@ -22,7 +22,8 @@ page.viewportSize = {
 page.open(args[1], function (status) {
     // Check for page load success
     if (status !== 'success') {
-        console.log('Unable to access network');
+        console.log('Unable to access network: ' + status);
+        phantom.exit();
         return;
     }
 
@@ -61,6 +62,7 @@ page.open(args[1], function (status) {
                 var index = async_metrics.indexOf(msg.metric);
     
                 if (-1 == index) {
+                    phantom.exit();
                     return;
                 }
                 

--- a/data/compilePhantomjsScript.js.php
+++ b/data/compilePhantomjsScript.js.php
@@ -1,11 +1,6 @@
 <?php
-ini_set('display_errors', true);
-
-//Initialize all settings and autoloaders
-require_once(__DIR__ . "/../init.php");
 
 $runner = new \SiteMaster\Core\Auditor\PhantomjsRunner();
-
 $phantom_js_file = $runner->getCompiledScriptLocation();
 
 ob_start();

--- a/data/compilePhantomjsScript.js.php
+++ b/data/compilePhantomjsScript.js.php
@@ -81,12 +81,12 @@ page.open(args[1], function (status) {
                 if (async_metrics.length == 0) {
                     //We are no longer waiting on any metrics... exit
                     
-                    console.log(JSON.stringify(results, null, '  '));
+                    console.log(JSON.stringify(results));
                     phantom.exit();
                 }
             };
         } else {
-            console.log(JSON.stringify(results, null, '  '));
+            console.log(JSON.stringify(results));
     
             phantom.exit();
         }

--- a/data/update-2016102401.sql
+++ b/data/update-2016102401.sql
@@ -1,0 +1,1 @@
+ALTER TABLE page_marks ADD help_text TEXT NULL DEFAULT NULL;

--- a/plugins/example/phantomjs.js.php
+++ b/plugins/example/phantomjs.js.php
@@ -1,0 +1,5 @@
+//Set properties in the metric_results object.
+
+metric_results.page_title = page.evaluate(function() {
+    return document.title;
+});

--- a/plugins/example/phantomjs.js.php
+++ b/plugins/example/phantomjs.js.php
@@ -1,5 +1,16 @@
 //Set properties in the metric_results object.
 
+//1: Example of how to run a synchronous test
 metric_results.page_title = page.evaluate(function() {
     return document.title;
+});
+
+//2. Async example
+async_metrics.push('example'); //Tell sitemaster that it needs to wait for an async test (push the machine name of the metric)
+page.evaluateAsync(function() {
+    var phantomResults = {}; //Create a phantom results object
+    phantomResults.metric = 'example'; //Set the metric name to the metric's machine name (must be the same as what was pushed to the async_metrics array)
+    phantomResults.results = {}; //Create a results object
+    phantomResults.results.async_page_title = document.title; //Set the data
+    window.callPhantom(phantomResults); //pass back to sitemaster
 });

--- a/plugins/example/src/Metric.php
+++ b/plugins/example/src/Metric.php
@@ -3,9 +3,11 @@ namespace SiteMaster\Plugins\Example;
 
 use SiteMaster\Core\Auditor\Logger\Metrics;
 use SiteMaster\Core\Auditor\MetricInterface;
+use SiteMaster\Core\Exception;
 use SiteMaster\Core\Registry\Site;
 use SiteMaster\Core\Auditor\Scan;
 use SiteMaster\Core\Auditor\Site\Page;
+use SiteMaster\Core\RuntimeException;
 
 class Metric extends MetricInterface
 {
@@ -85,6 +87,11 @@ class Metric extends MetricInterface
         $mark = $this->getMark('test2', 'Just a test', 5);
 
         $page->addMark($mark);
+        
+        if (!$this->phantomjsResults || isset($this->phantomjsResults['exception'])) {
+            //mark this metric as incomplete
+            throw new RuntimeException('phantomjs results are required for the example program');
+        }
         
         if (isset($this->phantomjsResults['page_title'])) {
             $mark = $this->getMark('example_page_title', 'Page title test', 0);

--- a/plugins/example/src/Metric.php
+++ b/plugins/example/src/Metric.php
@@ -85,6 +85,13 @@ class Metric extends MetricInterface
         $mark = $this->getMark('test2', 'Just a test', 5);
 
         $page->addMark($mark);
+        
+        if (isset($this->phantomjsResults['page_title'])) {
+            $mark = $this->getMark('example_page_title', 'Page title test', 0);
+            $page->addMark($mark, [
+                'value_found' => $this->phantomjsResults['page_title']
+            ]);
+        }
 
         return true;
     }

--- a/plugins/example/src/Metric.php
+++ b/plugins/example/src/Metric.php
@@ -88,22 +88,22 @@ class Metric extends MetricInterface
 
         $page->addMark($mark);
         
-        if (!$this->phantomjsResults || isset($this->phantomjsResults['exception'])) {
+        if (!$this->phantomjs_results || isset($this->phantomjs_results['exception'])) {
             //mark this metric as incomplete
             throw new RuntimeException('phantomjs results are required for the example program');
         }
         
-        if (isset($this->phantomjsResults['page_title'])) {
+        if (isset($this->phantomjs_results['page_title'])) {
             $mark = $this->getMark('example_page_title', 'Page title test', 0);
             $page->addMark($mark, [
-                'value_found' => $this->phantomjsResults['page_title']
+                'value_found' => $this->phantomjs_results['page_title']
             ]);
         }
 
-        if (isset($this->phantomjsResults['async_page_title'])) {
+        if (isset($this->phantomjs_results['async_page_title'])) {
             $mark = $this->getMark('example_async_page_title', 'Async page title test', 0);
             $page->addMark($mark, [
-                'value_found' => $this->phantomjsResults['async_page_title']
+                'value_found' => $this->phantomjs_results['async_page_title']
             ]);
         }
         

--- a/plugins/example/src/Metric.php
+++ b/plugins/example/src/Metric.php
@@ -100,6 +100,13 @@ class Metric extends MetricInterface
             ]);
         }
 
+        if (isset($this->phantomjsResults['async_page_title'])) {
+            $mark = $this->getMark('example_async_page_title', 'Async page title test', 0);
+            $page->addMark($mark, [
+                'value_found' => $this->phantomjsResults['async_page_title']
+            ]);
+        }
+        
         return true;
     }
 

--- a/scripts/compilePhantomjsScript.js.php
+++ b/scripts/compilePhantomjsScript.js.php
@@ -17,6 +17,13 @@ var args = require('system').args;
 var fs = require('fs');
 var page = require('webpage').create();
 
+page.settings.userAgent = '<?php echo SiteMaster\Core\Config::get('USER_AGENT') ?>/phantom';
+
+page.viewportSize = {
+    width: <?php echo SiteMaster\Core\Config::get('PHANTOMJS_WIDTH') ?>,
+    height: <?php echo SiteMaster\Core\Config::get('PHANTOMJS_HEIGHT') ?>,
+};
+
 page.open(args[1], function (status) {
     // Check for page load success
     if (status !== 'success') {

--- a/scripts/compilePhantomjsScript.js.php
+++ b/scripts/compilePhantomjsScript.js.php
@@ -42,6 +42,7 @@ page.open(args[1], function (status) {
                 <?php include $metric_phantom_js_file; ?>
             } catch (e) {
                 //There was an error...
+                metric_results.exception = e;
             }
             results.<?php echo $metric->getMachineName() ?> = metric_results;
             <?php

--- a/scripts/compilePhantomjsScript.js.php
+++ b/scripts/compilePhantomjsScript.js.php
@@ -1,0 +1,61 @@
+<?php
+ini_set('display_errors', true);
+
+//Initialize all settings and autoloaders
+require_once(__DIR__ . "/../init.php");
+
+$runner = new \SiteMaster\Core\Auditor\PhantomjsRunner();
+
+$phantom_js_file = $runner->getCompiledScriptLocation();
+
+ob_start();
+?>
+
+/*global phantom */
+
+var args = require('system').args;
+var fs = require('fs');
+var page = require('webpage').create();
+
+page.open(args[1], function (status) {
+    // Check for page load success
+    if (status !== 'success') {
+        console.log('Unable to access network');
+        return;
+    }
+
+    var results = {};
+
+    <?php
+    $metrics = \SiteMaster\Core\Plugin\PluginManager::getManager()->getMetrics();
+    foreach ($metrics as $metric) {
+        /**
+         * @var \SiteMaster\Core\Auditor\MetricInterface $metric
+         */
+    
+        $metric_phantom_js_file = $metric->getPhantomjsScript();
+    
+        if (file_exists($metric_phantom_js_file)) {
+            ?>
+            var metric_results = {};
+            try {
+                <?php include $metric_phantom_js_file; ?>
+            } catch (e) {
+                //There was an error...
+            }
+            results.<?php echo $metric->getMachineName() ?> = metric_results;
+            <?php
+        }
+    }
+    ?>
+
+    console.log(JSON.stringify(results, null, '  '));
+
+    phantom.exit();
+});
+
+<?php
+$script = ob_get_contents();
+ob_end_clean();
+    
+$result = file_put_contents($phantom_js_file, $script);

--- a/scripts/daemon.php
+++ b/scripts/daemon.php
@@ -25,6 +25,10 @@ foreach ($running as $page) {
     $page->rescheduleScan();
 }
 
+//Regenerate the compiled phantomjs script to account for changes
+$phantomjs_runner = new \SiteMaster\Core\Auditor\PhantomjsRunner();
+$phantomjs_runner->deleteCompliedScript();
+
 $total_incomplete = 0;
 $total_checked    = 0;
 $current_site     = false;

--- a/src/SiteMaster/Core/Auditor/Logger/Metrics.php
+++ b/src/SiteMaster/Core/Auditor/Logger/Metrics.php
@@ -32,17 +32,17 @@ class Metrics extends \Spider_LoggerAbstract
 
     /**
      * 
-     * @var array
+     * @var false|array
      */
-    protected $phantomjsResults = [];
+    protected $phantomjs_results = false;
 
-    function __construct(\Spider $spider, Scan $scan, Site $site, Page $page, $phantomjsResults)
+    function __construct(\Spider $spider, Scan $scan, Site $site, Page $page, $phantomjs_results)
     {
         $this->spider = $spider;
         $this->scan = $scan;
         $this->site = $site;
         $this->page = $page;
-        $this->phantomjsResults = $phantomjsResults;
+        $this->phantomjs_results = $phantomjs_results;
     }
 
     public function log($uri, $depth, DOMXPath $xpath)
@@ -53,13 +53,13 @@ class Metrics extends \Spider_LoggerAbstract
             /**
              * @var \SiteMaster\Core\Auditor\MetricInterface $metric
              */
-            
-            $metricPhantomResults = false;
+
+            $metric_phantom_results = false;
             
             $plugin = $metric->getPlugin();
             
-            if (isset($this->phantomjsResults[$plugin->getMachineName()])) {
-                $metricPhantomResults = $this->phantomjsResults[$plugin->getMachineName()];
+            if (isset($this->phantomjs_results[$plugin->getMachineName()])) {
+                $metric_phantom_results = $this->phantomjs_results[$plugin->getMachineName()];
                 if (isset($metricPhantomResults['exception'])) {
                     Util::log(Logger::ERROR, 'phantomjs metric exception', array(
                         'result' => $metricPhantomResults,
@@ -67,7 +67,7 @@ class Metrics extends \Spider_LoggerAbstract
                 }
             }
             
-            $metric->performScan($uri, $xpath, $depth, $this->page, $this, $metricPhantomResults);
+            $metric->performScan($uri, $xpath, $depth, $this->page, $this, $metric_phantom_results);
         }
     }
 

--- a/src/SiteMaster/Core/Auditor/Logger/Metrics.php
+++ b/src/SiteMaster/Core/Auditor/Logger/Metrics.php
@@ -28,12 +28,19 @@ class Metrics extends \Spider_LoggerAbstract
      */
     protected $page = false;
 
-    function __construct(\Spider $spider, Scan $scan, Site $site, Page $page)
+    /**
+     * 
+     * @var array
+     */
+    protected $phantomjsResults = [];
+
+    function __construct(\Spider $spider, Scan $scan, Site $site, Page $page, $phantomjsResults)
     {
         $this->spider = $spider;
         $this->scan = $scan;
         $this->site = $site;
         $this->page = $page;
+        $this->phantomjsResults = $phantomjsResults;
     }
 
     public function log($uri, $depth, DOMXPath $xpath)
@@ -41,7 +48,19 @@ class Metrics extends \Spider_LoggerAbstract
         $metrics = new \SiteMaster\Core\Auditor\Metrics();
         
         foreach ($metrics as $metric) {
-            $metric->performScan($uri, $xpath, $depth, $this->page, $this);
+            /**
+             * @var \SiteMaster\Core\Auditor\MetricInterface $metric
+             */
+            
+            $metricPhantomResults = [];
+            
+            $plugin = $metric->getPlugin();
+            
+            if (isset($this->phantomjsResults[$plugin->getMachineName()])) {
+                $metricPhantomResults = $this->phantomjsResults[$plugin->getMachineName()];
+            }
+            
+            $metric->performScan($uri, $xpath, $depth, $this->page, $this, $metricPhantomResults);
         }
     }
 

--- a/src/SiteMaster/Core/Auditor/Logger/Metrics.php
+++ b/src/SiteMaster/Core/Auditor/Logger/Metrics.php
@@ -56,10 +56,8 @@ class Metrics extends \Spider_LoggerAbstract
 
             $metric_phantom_results = false;
             
-            $plugin = $metric->getPlugin();
-            
-            if (isset($this->phantomjs_results[$plugin->getMachineName()])) {
-                $metric_phantom_results = $this->phantomjs_results[$plugin->getMachineName()];
+            if (isset($this->phantomjs_results[$metric->getMachineName()])) {
+                $metric_phantom_results = $this->phantomjs_results[$metric->getMachineName()];
                 if (isset($metricPhantomResults['exception'])) {
                     Util::log(Logger::ERROR, 'phantomjs metric exception', array(
                         'result' => $metricPhantomResults,

--- a/src/SiteMaster/Core/Auditor/Logger/Metrics.php
+++ b/src/SiteMaster/Core/Auditor/Logger/Metrics.php
@@ -2,9 +2,11 @@
 namespace SiteMaster\Core\Auditor\Logger;
 
 use DOMXPath;
+use Monolog\Logger;
 use SiteMaster\Core\Registry\Site;
 use SiteMaster\Core\Auditor\Scan;
 use SiteMaster\Core\Auditor\Site\Page;
+use SiteMaster\Core\Util;
 
 class Metrics extends \Spider_LoggerAbstract
 {
@@ -52,12 +54,17 @@ class Metrics extends \Spider_LoggerAbstract
              * @var \SiteMaster\Core\Auditor\MetricInterface $metric
              */
             
-            $metricPhantomResults = [];
+            $metricPhantomResults = false;
             
             $plugin = $metric->getPlugin();
             
             if (isset($this->phantomjsResults[$plugin->getMachineName()])) {
                 $metricPhantomResults = $this->phantomjsResults[$plugin->getMachineName()];
+                if (isset($metricPhantomResults['exception'])) {
+                    Util::log(Logger::ERROR, 'phantomjs metric exception', array(
+                        'result' => $metricPhantomResults,
+                    ));
+                }
             }
             
             $metric->performScan($uri, $xpath, $depth, $this->page, $this, $metricPhantomResults);

--- a/src/SiteMaster/Core/Auditor/MetricInterface.php
+++ b/src/SiteMaster/Core/Auditor/MetricInterface.php
@@ -13,7 +13,7 @@ abstract class MetricInterface
     
     public $options;
     public $plugin_name;
-    protected $phantomjsResults = false;
+    protected $phantomjs_results = false;
 
     /**
      * @param string $plugin_name (The plugin machine name for this metric)
@@ -115,13 +115,13 @@ abstract class MetricInterface
      * @param int $depth - the current depth of the scan
      * @param \SiteMaster\Core\Auditor\Site\Page $page - the current page record
      * @param Logger\Metrics $logger
-     * @param array $phantomjsResults
+     * @param array $phantomjs_results
      */
-    public function performScan($uri, \DOMXPath $xpath, $depth, Page $page, Logger\Metrics $logger, $phantomjsResults)
+    public function performScan($uri, \DOMXPath $xpath, $depth, Page $page, Logger\Metrics $logger, $phantomjs_results)
     {
         try {
             //scan
-            $this->phantomjsResults = $phantomjsResults;
+            $this->phantomjs_results = $phantomjs_results;
             $completed = $this->scan($uri, $xpath, $depth, $page, $logger);
         } catch (\Exception $exception) {
             //Some sort of error occurred.  Mark this metric as incomplete

--- a/src/SiteMaster/Core/Auditor/MetricInterface.php
+++ b/src/SiteMaster/Core/Auditor/MetricInterface.php
@@ -9,6 +9,8 @@ use SiteMaster\Core\Util;
 
 abstract class MetricInterface
 {
+    const PHANTOMJS_SCRIPT_NAME = 'phantomjs.js.php';
+    
     public $options;
     public $plugin_name;
 
@@ -376,5 +378,23 @@ abstract class MetricInterface
     function formatValueFound($machine_name, $value_found)
     {
         return $value_found;
+    }
+
+    /**
+     * Get the phantomjs script name
+     * 
+     * If this metric does not implement it, return false
+     * 
+     * @return bool|string
+     */
+    public function getPhantomjsScript()
+    {
+        $file = $this->getPlugin()->getRootDirectory() . '/' . self::PHANTOMJS_SCRIPT_NAME;
+        
+        if (file_exists($file)) {
+            return $file;
+        }
+        
+        return false;
     }
 }

--- a/src/SiteMaster/Core/Auditor/MetricInterface.php
+++ b/src/SiteMaster/Core/Auditor/MetricInterface.php
@@ -13,7 +13,7 @@ abstract class MetricInterface
     
     public $options;
     public $plugin_name;
-    protected $phantomjsResults = [];
+    protected $phantomjsResults = false;
 
     /**
      * @param string $plugin_name (The plugin machine name for this metric)

--- a/src/SiteMaster/Core/Auditor/MetricInterface.php
+++ b/src/SiteMaster/Core/Auditor/MetricInterface.php
@@ -13,6 +13,7 @@ abstract class MetricInterface
     
     public $options;
     public $plugin_name;
+    protected $phantomjsResults = [];
 
     /**
      * @param string $plugin_name (The plugin machine name for this metric)
@@ -114,11 +115,13 @@ abstract class MetricInterface
      * @param int $depth - the current depth of the scan
      * @param \SiteMaster\Core\Auditor\Site\Page $page - the current page record
      * @param Logger\Metrics $logger
+     * @param array $phantomjsResults
      */
-    public function performScan($uri, \DOMXPath $xpath, $depth, Page $page, Logger\Metrics $logger)
+    public function performScan($uri, \DOMXPath $xpath, $depth, Page $page, Logger\Metrics $logger, $phantomjsResults)
     {
         try {
             //scan
+            $this->phantomjsResults = $phantomjsResults;
             $completed = $this->scan($uri, $xpath, $depth, $page, $logger);
         } catch (\Exception $exception) {
             //Some sort of error occurred.  Mark this metric as incomplete

--- a/src/SiteMaster/Core/Auditor/PhantomjsRunner.php
+++ b/src/SiteMaster/Core/Auditor/PhantomjsRunner.php
@@ -3,6 +3,7 @@ namespace SiteMaster\Core\Auditor;
 
 use Monolog\Logger;
 use SiteMaster\Core\Config;
+use SiteMaster\Core\Plugin\PluginManager;
 use SiteMaster\Core\Util;
 
 class PhantomjsRunner
@@ -20,6 +21,13 @@ class PhantomjsRunner
      */
     public function run($url)
     {
+        //Do we need to run phantomjs? (do any metrics use it?)
+        $pluginManager = PluginManager::getManager();
+        
+        if (!$pluginManager->phantomJsTestsExist()) {
+            return false;
+        }
+        
         $script = $this->getCompiledScriptLocation();
         
         if (!file_exists($script)) {

--- a/src/SiteMaster/Core/Auditor/PhantomjsRunner.php
+++ b/src/SiteMaster/Core/Auditor/PhantomjsRunner.php
@@ -1,0 +1,70 @@
+<?php
+namespace SiteMaster\Core\Auditor;
+
+use SiteMaster\Core\Config;
+use SiteMaster\Core\Util;
+
+class PhantomjsRunner
+{
+    public function __construct()
+    {
+        
+    }
+
+    /**
+     * Run phantomjs script
+     * 
+     * @param $url
+     * @return array|mixed|string
+     */
+    public function run($url)
+    {
+        $script = $this->getCompiledScriptLocation();
+        
+        if (!file_exists($script)) {
+            //we need to generate the script
+            $this->generateCompliedScript();
+        }
+        
+        $command = Config::get('PATH_PHANTOMJS') . ' ' . $this->getCompiledScriptLocation() . ' ' . escapeshellarg($url);
+        
+        $result = shell_exec($command);
+        
+        if (!$result) {
+            return [];
+        }
+        
+        $result = json_decode($result, true);
+        
+        return $result;
+    }
+
+    /**
+     * Compile (or recompile) the the phantomjs script
+     * 
+     * @return string
+     */
+    protected function generateCompliedScript()
+    {
+        $command = Config::get('PATH_PHP') . ' ' . Util::getRootDir() . '/scripts/compilePhantomjsScript.js.php';
+        return shell_exec($command);
+    }
+
+    /**
+     * Get the compiled phantomjs script location
+     * 
+     * @return string
+     */
+    public function getCompiledScriptLocation()
+    {
+        return Util::getRootDir() . '/scripts/sitemaster_phantom_complied.js';
+    }
+
+    /**
+     * Delete the complied phantomjs script
+     */
+    public function deleteCompliedScript()
+    {
+        unlink($this->getCompiledScriptLocation());
+    }
+}

--- a/src/SiteMaster/Core/Auditor/PhantomjsRunner.php
+++ b/src/SiteMaster/Core/Auditor/PhantomjsRunner.php
@@ -56,8 +56,7 @@ class PhantomjsRunner
      */
     protected function generateCompliedScript()
     {
-        $command = Config::get('PATH_PHP') . ' ' . Util::getRootDir() . '/scripts/compilePhantomjsScript.js.php';
-        return shell_exec($command);
+        include Util::getRootDir() . '/data/compilePhantomjsScript.js.php';
     }
 
     /**
@@ -67,7 +66,11 @@ class PhantomjsRunner
      */
     public function getCompiledScriptLocation()
     {
-        return Util::getRootDir() . '/scripts/sitemaster_phantom_complied.js';
+        if (Config::get('ENVIRONMENT') == Config::ENVIRONMENT_TESTING) {
+            return Util::getRootDir() . '/sitemaster_phantom_complied_test.js';
+        }
+        
+        return Util::getRootDir() . '/data/sitemaster_phantom_complied.js';
     }
 
     /**
@@ -75,6 +78,6 @@ class PhantomjsRunner
      */
     public function deleteCompliedScript()
     {
-        unlink($this->getCompiledScriptLocation());
+        @unlink($this->getCompiledScriptLocation());
     }
 }

--- a/src/SiteMaster/Core/Auditor/PhantomjsRunner.php
+++ b/src/SiteMaster/Core/Auditor/PhantomjsRunner.php
@@ -42,8 +42,18 @@ class PhantomjsRunner
         if (!$result) {
             return false;
         }
+
+        //Output MAY contain many lines, but the json response is always on one line.
+        $output = explode(PHP_EOL, $result);
         
-        $json = json_decode($result, true);
+        $json = false;
+        foreach ($output as $line) {
+            //Loop over each line and find the json response
+            if ($json = json_decode($line, true)) {
+                //Found it... return the data.
+                break;
+            }
+        }
         
         if (!$json) {
             //Log the error

--- a/src/SiteMaster/Core/Auditor/PhantomjsRunner.php
+++ b/src/SiteMaster/Core/Auditor/PhantomjsRunner.php
@@ -1,6 +1,7 @@
 <?php
 namespace SiteMaster\Core\Auditor;
 
+use Monolog\Logger;
 use SiteMaster\Core\Config;
 use SiteMaster\Core\Util;
 
@@ -31,12 +32,21 @@ class PhantomjsRunner
         $result = shell_exec($command);
         
         if (!$result) {
-            return [];
+            return false;
         }
         
-        $result = json_decode($result, true);
+        $json = json_decode($result, true);
         
-        return $result;
+        if (!$json) {
+            //Log the error
+            Util::log(Logger::ERROR, 'Error parsing phantomjs', array(
+                'result' => $result,
+            ));
+            
+            return false;
+        }
+        
+        return $json;
     }
 
     /**

--- a/src/SiteMaster/Core/Auditor/PhantomjsRunner.php
+++ b/src/SiteMaster/Core/Auditor/PhantomjsRunner.php
@@ -67,10 +67,10 @@ class PhantomjsRunner
     public function getCompiledScriptLocation()
     {
         if (Config::get('ENVIRONMENT') == Config::ENVIRONMENT_TESTING) {
-            return Util::getRootDir() . '/sitemaster_phantom_complied_test.js';
+            return Util::getRootDir() . '/scripts/sitemaster_phantom_complied_test.js';
         }
         
-        return Util::getRootDir() . '/data/sitemaster_phantom_complied.js';
+        return Util::getRootDir() . '/scripts/sitemaster_phantom_complied.js';
     }
 
     /**

--- a/src/SiteMaster/Core/Auditor/Site/Page.php
+++ b/src/SiteMaster/Core/Auditor/Site/Page.php
@@ -331,8 +331,8 @@ class Page extends Record
         }
         
         //Run phantomjs tests against the page (we need to do this here so we can pass the results to the metrics)
-        $phantomRunner = new PhantomjsRunner();
-        $phantomjs_results = $phantomRunner->run($this->uri);
+        $phantom_runner = new PhantomjsRunner();
+        $phantomjs_results = $phantom_runner->run($this->uri);
         
         $spider->addLogger(new Links($spider, $this));
         $spider->addLogger($page_title_logger);

--- a/src/SiteMaster/Core/Auditor/Site/Page.php
+++ b/src/SiteMaster/Core/Auditor/Site/Page.php
@@ -461,7 +461,7 @@ class Page extends Record
     public function computeLetterGrade(Page\MetricGrades\AllForPage $metric_grades, $percent_grade)
     {
         foreach ($metric_grades as $grade) {
-            if ($grade->isIncomplete()) {
+            if ($grade->isIncomplete() && $grade->weight > 0) {
                 return GradingHelper::GRADE_INCOMPLETE;
             }
         }

--- a/src/SiteMaster/Core/Auditor/Site/Page.php
+++ b/src/SiteMaster/Core/Auditor/Site/Page.php
@@ -8,6 +8,7 @@ use SiteMaster\Core\Auditor\GradingHelper;
 use SiteMaster\Core\Auditor\Logger\Links;
 use SiteMaster\Core\Auditor\Metric\Mark;
 use SiteMaster\Core\Auditor\Parser\HTML5;
+use SiteMaster\Core\Auditor\PhantomjsRunner;
 use SiteMaster\Core\Config;
 use SiteMaster\Core\Registry\Site\Member;
 use SiteMaster\Core\Registry\Site;
@@ -329,9 +330,13 @@ class Page extends Record
             $spider->addLogger(new Scheduler($spider, $scan, $site));
         }
         
+        //Run phantomjs tests against the page (we need to do this here so we can pass the results to the metrics)
+        $phantomRunner = new PhantomjsRunner();
+        $phantomjs_results = $phantomRunner->run($this->uri);
+        
         $spider->addLogger(new Links($spider, $this));
         $spider->addLogger($page_title_logger);
-        $spider->addLogger(new Metrics($spider, $scan, $site, $this));
+        $spider->addLogger(new Metrics($spider, $scan, $site, $this, $phantomjs_results));
 
         try {
             $spider->processPage($this->getSanitizedURI(), 1);

--- a/src/SiteMaster/Core/Auditor/Site/Page/Mark.php
+++ b/src/SiteMaster/Core/Auditor/Site/Page/Mark.php
@@ -15,6 +15,7 @@ class Mark extends Record
     public $line;                  //INT
     public $col;                   //INT
     public $value_found;           //TEXT (The incorrect value that was found)
+    public $help_text;             //TEXT (help text in markdown format)
 
     public function keys()
     {

--- a/src/SiteMaster/Core/Config.php
+++ b/src/SiteMaster/Core/Config.php
@@ -55,7 +55,7 @@ class Config
         'PATH_PHANTOMJS' => 'phantomjs',
         'PHANTOMJS_WIDTH' => 480,
         'PHANTOMJS_HEIGHT' => 800,
-        'PHANTOMJS_WAIT' => 100, //milliseconds before test execution (let the page run just a little bit first)
+        'PHANTOMJS_WAIT' => 800, //milliseconds before test execution (let the page run just a little bit first)
     
         //Loggers
         'PAGE_TITLE_LOGGER' => '\\SiteMaster\\Core\\Auditor\\Logger\\PageTitle',

--- a/src/SiteMaster/Core/Config.php
+++ b/src/SiteMaster/Core/Config.php
@@ -54,6 +54,8 @@ class Config
         //paths
         'PATH_PHP'       => 'php',
         'PATH_PHANTOMJS' => 'phantomjs',
+        'PHANTOMJS_WIDTH' => 480,
+        'PHANTOMJS_HEIGHT' => 800,
     
         //Loggers
         'PAGE_TITLE_LOGGER' => '\\SiteMaster\\Core\\Auditor\\Logger\\PageTitle',

--- a/src/SiteMaster/Core/Config.php
+++ b/src/SiteMaster/Core/Config.php
@@ -50,6 +50,10 @@ class Config
         'PAGE_LINK_TTL'       => '+1 hour',  //strtotime notation for the length of time that a link is to be considered 'fresh'.
 
         'SECONDS_BETWEEN_REQUESTS' => 1,
+        
+        //paths
+        'PATH_PHP'       => 'php',
+        'PATH_PHANTOMJS' => 'phantomjs',
     
         //Loggers
         'PAGE_TITLE_LOGGER' => '\\SiteMaster\\Core\\Auditor\\Logger\\PageTitle',

--- a/src/SiteMaster/Core/Config.php
+++ b/src/SiteMaster/Core/Config.php
@@ -56,6 +56,7 @@ class Config
         'PATH_PHANTOMJS' => 'phantomjs',
         'PHANTOMJS_WIDTH' => 480,
         'PHANTOMJS_HEIGHT' => 800,
+        'PHANTOMJS_WAIT' => 100, //milliseconds before test execution (let the page run just a little bit first)
     
         //Loggers
         'PAGE_TITLE_LOGGER' => '\\SiteMaster\\Core\\Auditor\\Logger\\PageTitle',

--- a/src/SiteMaster/Core/Config.php
+++ b/src/SiteMaster/Core/Config.php
@@ -52,7 +52,6 @@ class Config
         'SECONDS_BETWEEN_REQUESTS' => 1,
         
         //paths
-        'PATH_PHP'       => 'php',
         'PATH_PHANTOMJS' => 'phantomjs',
         'PHANTOMJS_WIDTH' => 480,
         'PHANTOMJS_HEIGHT' => 800,

--- a/src/SiteMaster/Core/DBTests/AbstractMetricDBTest.php
+++ b/src/SiteMaster/Core/DBTests/AbstractMetricDBTest.php
@@ -15,7 +15,7 @@ abstract class AbstractMetricDBTest extends DBTestCase
 {
     const INTEGRATION_TESTING_URL = 'http://unlsitemaster.github.io/test_site/';
     
-    protected $originalPlugins = '[]';
+    protected static $originalPlugins = '[]';
 
     public function installBaseDB()
     {
@@ -87,17 +87,17 @@ abstract class AbstractMetricDBTest extends DBTestCase
      */
     abstract function getPlugin();
     
-    protected function setUp()
+    public static function setUpBeforeClass()
     {
-        parent::setUp();
+        parent::setUpBeforeClass();
         //Store the original plugins so that we can revert back to them
-        $this->originalPlugins = Config::get('PLUGINS');
+        self::$originalPlugins = Config::get('PLUGINS');
     }
 
-    protected function tearDown()
+    public static function tearDownAfterClass()
     {
-        parent::tearDown();
+        parent::tearDownAfterClass();
         //Reset to the original plugins
-        Config::set('PLUGINS', $this->originalPlugins);
+        Config::set('PLUGINS', self::$originalPlugins);
     }
 }

--- a/src/SiteMaster/Core/DBTests/AbstractMetricDBTest.php
+++ b/src/SiteMaster/Core/DBTests/AbstractMetricDBTest.php
@@ -14,6 +14,8 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 abstract class AbstractMetricDBTest extends DBTestCase
 {
     const INTEGRATION_TESTING_URL = 'http://unlsitemaster.github.io/test_site/';
+    
+    protected $originalPlugins = '[]';
 
     public function installBaseDB()
     {
@@ -82,4 +84,18 @@ abstract class AbstractMetricDBTest extends DBTestCase
      * @return \SiteMaster\Core\Plugin\PluginInterface
      */
     abstract function getPlugin();
+    
+    protected function setUp()
+    {
+        parent::setUp();
+        //Store the original plugins so that we can revert back to them
+        $this->originalPlugins = Config::get('PLUGINS');
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        //Reset to the original plugins
+        Config::set('PLUGINS', $this->originalPlugins);
+    }
 }

--- a/src/SiteMaster/Core/DBTests/AbstractMetricDBTest.php
+++ b/src/SiteMaster/Core/DBTests/AbstractMetricDBTest.php
@@ -49,6 +49,8 @@ abstract class AbstractMetricDBTest extends DBTestCase
                 true //force re-initialize
             );
         }
+
+        PluginManager::getManager()->initializeMetrics();
     }
 
     protected function runScan()

--- a/src/SiteMaster/Core/DBTests/DBTestCase.php
+++ b/src/SiteMaster/Core/DBTests/DBTestCase.php
@@ -26,6 +26,8 @@ class DBTestCase extends \PHPUnit_Framework_TestCase
             $plugin = $pluginManager->getPluginInfo($plugin_name);
             $plugin->performUpdate();
         }
+        
+        $pluginManager->initializeMetrics();
     }
 
     public function cleanDB()

--- a/src/SiteMaster/Core/DBTests/DBTestCase.php
+++ b/src/SiteMaster/Core/DBTests/DBTestCase.php
@@ -19,6 +19,13 @@ class DBTestCase extends \PHPUnit_Framework_TestCase
         } catch (\Exception $e) {
             $this->markTestSkipped('Test database is not available, database tests were skipped: ' . $e->getMessage());
         }
+
+        $pluginManager = \SiteMaster\Core\Plugin\PluginManager::getManager();
+        foreach ($pluginManager->getAllPlugins() as $plugin_name) {
+            \SiteMaster\Core\Util::connectTestDB();
+            $plugin = $pluginManager->getPluginInfo($plugin_name);
+            $plugin->performUpdate();
+        }
     }
 
     public function cleanDB()

--- a/src/SiteMaster/Core/Plugin.php
+++ b/src/SiteMaster/Core/Plugin.php
@@ -235,6 +235,14 @@ class Plugin extends PluginInterface
                 return false;
             }
         }
+
+        if ($previousVersion <= 2016100701) {
+            $sql = file_get_contents(Util::getRootDir() . "/data/update-2016102401.sql");
+
+            if (!Util::execMultiQuery($sql, true)) {
+                return false;
+            }
+        }
         
         return true;
     }
@@ -260,7 +268,7 @@ class Plugin extends PluginInterface
      */
     public function getVersion()
     {
-        return 2016100701;
+        return 2016102401;
     }
 
     /**

--- a/src/SiteMaster/Core/Plugin/PluginInterface.php
+++ b/src/SiteMaster/Core/Plugin/PluginInterface.php
@@ -104,7 +104,6 @@ abstract class PluginInterface
         $plugins[$this->getMachineName()] = $this->getVersion();
 
         PluginManager::getManager()->updateInstalledPlugins($plugins);
-        
         if ($metric = $this->getMetric()) {
             //Create a metric record if we don't have one yet.
             $metric_record = $metric->getMetricRecord();
@@ -199,6 +198,11 @@ abstract class PluginInterface
     public function performUpdate()
     {
         $method = $this->getUpdateMethod();
+        
+        if (!$method) {
+            return false; //No updates required
+        }
+        
         return $this->$method();
     }
 

--- a/src/SiteMaster/Core/Plugin/PluginManager.php
+++ b/src/SiteMaster/Core/Plugin/PluginManager.php
@@ -18,6 +18,8 @@ class PluginManager
     protected $metrics = array();
 
     protected static $singleton = false;
+    
+    protected $has_phantomjs_tests = false;
 
     /**
      * Initialize the singleton
@@ -60,6 +62,11 @@ class PluginManager
         $this->initializePlugins($this->getInstalledPlugins());
         
         $this->initializeMetrics();
+    }
+    
+    public function phantomJsTestsExist()
+    {
+        return $this->has_phantomjs_tests;
     }
 
     /**
@@ -152,11 +159,16 @@ class PluginManager
     
     public function initializeMetrics()
     {
+        $this->metrics = [];
         foreach ($this->getAllPlugins() as $plugin_name) {
             $plugin = $this->getPluginInfo($plugin_name);
             
             if ($metric = $plugin->getMetric()) {
                 $this->metrics[$metric->getMachineName()] = $metric;
+                
+                if (!$this->has_phantomjs_tests && $metric->getMachineName()) {
+                    $this->has_phantomjs_tests = true;
+                }
             }
         }
     }

--- a/tests/SiteMaster/Core/Auditor/PhantomjsRunnerTest.php
+++ b/tests/SiteMaster/Core/Auditor/PhantomjsRunnerTest.php
@@ -1,0 +1,19 @@
+<?php
+namespace SiteMaster\Core\Auditor;
+
+use SiteMaster\Core\Config;
+
+class phantomjsRunnerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function testRun()
+    {
+        $runner = new PhantomjsRunner();
+        
+        $results = $runner->run(ScanDBTest::INTEGRATION_TESTING_URL);
+        
+        $this->assertArrayHasKey('page_title', $results['example']);
+    }
+}

--- a/tests/SiteMaster/Core/Auditor/ScanDBTest.php
+++ b/tests/SiteMaster/Core/Auditor/ScanDBTest.php
@@ -110,7 +110,7 @@ class ScanDBTest extends DBTestCase
             $this->assertEquals('B', $page->letter_grade);
             
             $this->assertEquals(2, $page->num_errors);
-            $this->assertEquals(1, $page->num_notices);
+            $this->assertEquals(2, $page->num_notices);
             
             $marks = $page->getMarks($example_metric->id);
             
@@ -118,7 +118,9 @@ class ScanDBTest extends DBTestCase
             foreach($marks as $mark) {
                 $mark_machine_names[] = $mark->getMark()->machine_name;
             }
-            $this->assertContains('example_page_title', $mark_machine_names, 'phanomjs integration should work');
+            
+            $this->assertContains('example_page_title', $mark_machine_names, 'phanomjs sync integration should work');
+            $this->assertContains('example_async_page_title', $mark_machine_names, 'phanomjs async integration should work');
         }
     }
 

--- a/tests/SiteMaster/Core/Auditor/ScanDBTest.php
+++ b/tests/SiteMaster/Core/Auditor/ScanDBTest.php
@@ -110,10 +110,16 @@ class ScanDBTest extends DBTestCase
             $this->assertEquals('B', $page->letter_grade);
             
             $this->assertEquals(2, $page->num_errors);
-            $this->assertEquals(0, $page->num_notices);
+            $this->assertEquals(1, $page->num_notices);
+            
+            $marks = $page->getMarks($example_metric->id);
+            
+            $mark_machine_names = [];
+            foreach($marks as $mark) {
+                $mark_machine_names[] = $mark->getMark()->machine_name;
+            }
+            $this->assertContains('example_page_title', $mark_machine_names, 'phanomjs integration should work');
         }
-        
-        //TODO: test the GPA
     }
 
     /**

--- a/tests/init.php
+++ b/tests/init.php
@@ -8,6 +8,9 @@ if (file_exists(__DIR__ . '/../config.inc.php')) {
     $config_file = __DIR__ . '/../config.inc.php';
 }
 
+@unlink(__DIR__.'/../plugins_testing.json');
+@unlink(__DIR__.'/../scripts/sitemaster_phantom_complied_test.js');
+
 require_once $config_file;
 
 //Prevent tests from running on the production db


### PR DESCRIPTION
This adds a central phantomjs process which metrics can hook into.  It is working but I'd like to do a few things before it is merged. Please feel free to review and I will let you know when I'm ready for it to be merged.

todo:
- [x] document phantomjs requirements including how to install phantomjs
- [x] allow configuring a wait period before phantomjs tests are ran against a page (wait a bit for the page to initialize)
