### PR TITLE
Prevent long URLs from being duplicated

### DIFF
--- a/scripts/daemon.php
+++ b/scripts/daemon.php
@@ -27,7 +27,7 @@ foreach ($running as $page) {
 
 //Regenerate the compiled headless script to account for changes
 $headless_runner = new \SiteMaster\Core\Auditor\HeadlessRunner();
-$headless_runner->deleteCompliedScript();
+$headless_runner->deleteCompiledScript();
 
 $total_incomplete = 0;
 $total_checked    = 0;

--- a/src/SiteMaster/Core/Auditor/HeadlessRunner.php
+++ b/src/SiteMaster/Core/Auditor/HeadlessRunner.php
@@ -32,7 +32,7 @@ class HeadlessRunner
         
         if (!file_exists($script)) {
             //we need to generate the script
-            $this->generateCompliedScript();
+            $this->generateCompiledScript();
         }
         
         $command = Config::get('XVFB_COMMAND')
@@ -75,7 +75,7 @@ class HeadlessRunner
      * 
      * @return string
      */
-    protected function generateCompliedScript()
+    protected function generateCompiledScript()
     {
         include Util::getRootDir() . '/data/compileHeadless.js.php';
     }
@@ -88,16 +88,16 @@ class HeadlessRunner
     public function getCompiledScriptLocation()
     {
         if (Config::get('ENVIRONMENT') == Config::ENVIRONMENT_TESTING) {
-            return Util::getRootDir() . '/tmp/sitemaster_headless_complied_test.js';
+            return Util::getRootDir() . '/tmp/sitemaster_headless_compiled_test.js';
         }
         
-        return Util::getRootDir() . '/tmp/sitemaster_headless_complied.js';
+        return Util::getRootDir() . '/tmp/sitemaster_headless_compiled.js';
     }
 
     /**
-     * Delete the complied headless script
+     * Delete the compiled headless script
      */
-    public function deleteCompliedScript()
+    public function deleteCompiledScript()
     {
         @unlink($this->getCompiledScriptLocation());
     }

--- a/src/SiteMaster/Core/Auditor/Site/Pages/URIForScan.php
+++ b/src/SiteMaster/Core/Auditor/Site/Pages/URIForScan.php
@@ -1,6 +1,7 @@
 <?php
 namespace SiteMaster\Core\Auditor\Site\Pages;
 
+use SiteMaster\Core\Auditor\Site\Page;
 use SiteMaster\Core\InvalidArgumentException;
 
 class URIForScan extends All
@@ -20,8 +21,10 @@ class URIForScan extends All
 
     public function getWhere()
     {
+        $sanitized_url = Page::sanitizeURI($this->options['uri']);
+        
         $where = "WHERE scans_id = " . (int)$this->options['scans_id'] . "
-            AND uri_hash = '" . self::escapeString(md5($this->options['uri'], true)) . "'";
+            AND uri_hash = '" . self::escapeString(md5($sanitized_url, true)) . "'";
         
         if (isset($this->options['not_id'])) {
             $where .= " AND scanned_page.id != " . (int)$this->options['not_id'];

--- a/tests/SiteMaster/Core/Auditor/ScanDBTest.php
+++ b/tests/SiteMaster/Core/Auditor/ScanDBTest.php
@@ -554,6 +554,35 @@ class ScanDBTest extends DBTestCase
 
         $this->assertEquals(array(3), $hot_spots->getInnerIterator()->getArrayCopy(), 'Fixed pages should not show up in the list of hot sports');
     }
+    
+    public function testIssue115()
+    {
+        $this->setUpDB();
+
+        //Get the test site
+        $site = Site::getByBaseURL(self::INTEGRATION_TESTING_URL);
+
+        //Start simulating a scan
+        $site->scheduleScan();
+
+        //get the new scan
+        $scan = $site->getLatestScan();
+        
+        $url = self::INTEGRATION_TESTING_URL;
+
+        //Create a super long url
+        for ($i = 1; $i <= 1000; $i++) {
+            $url .= 'testing/';
+        }
+
+        //insert the page
+        Page::createNewPage($scan->id, $site->id, $url, Page::FOUND_WITH_CRAWL, array(
+            'scan_type' => $scan->scan_type,
+        ));
+        
+        //now verify that we can detect that url was already scanned
+        $this->assertNotEquals(false, Page::getByScanIDAndURI($scan->id, $url));
+    }
 
     public function setUpDB()
     {

--- a/tests/init.php
+++ b/tests/init.php
@@ -9,7 +9,7 @@ if (file_exists(__DIR__ . '/../config.inc.php')) {
 }
 
 @unlink(__DIR__.'/../plugins_testing.json');
-@unlink(__DIR__.'/../scripts/sitemaster_phantom_complied_test.js');
+@unlink(__DIR__.'/../tmp/sitemaster_headless_compiled.js');
 
 require_once $config_file;
 


### PR DESCRIPTION
fixes #115

URLs that were longer than the mysql uri field length were being truncated, resulting in the same URL being scanned over and over again while ignoring the distinct page limit. This fixes that issue by truncating the URL before it even gets to mysql.