### PR TITLE
Define the auth plugin in the session

### DIFF
--- a/src/SiteMaster/Core/User/User.php
+++ b/src/SiteMaster/Core/User/User.php
@@ -55,28 +55,6 @@ class User extends Record
     }
 
     /**
-     * Get the authentication plugin for this user's provider
-     * 
-     * @return bool | \SiteMaster\Plugin\AuthenticationInterface object
-     */
-    public function getAuthenticationPlugin()
-    {
-        $authPlugins = PluginManager::getManager()->dispatchEvent(
-            GetAuthenticationPlugins::EVENT_NAME,
-            new GetAuthenticationPlugins()
-        );
-
-        foreach ($authPlugins->getPlugins() as $plugin) {
-            if ($plugin->getProviderMachineName() == $this->provider) {
-
-                return $plugin;
-            }
-        }
-        
-        return false;
-    }
-
-    /**
      * Get approved sites for this user
      * 
      * @return ApprovedForUser


### PR DESCRIPTION
Instead of doing this on the DB record, this should be done in the session. This is to handle the case where the same user is authenticated via different providers (for example, both CAS and Shib)