### PR TITLE
Multiple queue workers

### DIFF
--- a/data/compileHeadless.js.php
+++ b/data/compileHeadless.js.php
@@ -1,7 +1,9 @@
 <?php
 
-$runner = new \SiteMaster\Core\Auditor\HeadlessRunner();
-$headless_file = $runner->getCompiledScriptLocation();
+/**
+ * @var $this \SiteMaster\Core\Auditor\HeadlessRunner
+ */
+$headless_file = $this->getCompiledScriptLocation();
     
 //Make an array of metrics to use
 $metrics = [];

--- a/data/update-2017040701.sql
+++ b/data/update-2017040701.sql
@@ -1,0 +1,2 @@
+ALTER TABLE scanned_page ADD daemon_name VARCHAR(256) NULL;
+ALTER TABLE scanned_page ADD INDEX scanned_page_daeomon_name (daemon_name)

--- a/scripts/daemon.php
+++ b/scripts/daemon.php
@@ -19,15 +19,6 @@ if (!ctype_alnum($daemon_name)) {
     exit();
 }
 
-/**
- * TODO:
- * 1. [done] apply an ID to each daemon 'default', 'two', etc. As passed by a command line argument `php daemon.php this-is-the-id`
- * 2. [done] add a `daemon_name` to the scanned_page table
- * 3. [done] Running() should only look at jobs with the same daemon ID (only one worker at a time)
- * 4. [done] Queued() should not return any pages in which there is another page being scanned for the same site (to respect craw time limits)
- * 5. The generated headless files should be renamed to the current daemon worker to prevent concurrency issues
- */
-
 //There should only be one worker running at a time.  If there are running jobs, remove them and try again...
 $running = new SiteMaster\Core\Auditor\Site\Pages\Running([
     'daemon_name' => $daemon_name

--- a/scripts/daemon.php
+++ b/scripts/daemon.php
@@ -9,12 +9,15 @@ require_once(__DIR__ . "/../init.php");
 $config_file = __DIR__ . '/../config.inc.php';
 $last_modified = filemtime($config_file);
 
-if (!isset($argv[1])) {
-    echo "usage: php daemon.php id-of-daemon" . PHP_EOL;
-    exit();
+$daemon_name = 'default';
+if (isset($argv[1])) {
+    $daemon_name = $argv[1];
 }
 
-$daemon_name = $argv[1];
+if (!ctype_alnum($daemon_name)) {
+    echo 'daemon name must be alphanumeric' . PHP_EOL;
+    exit();
+}
 
 /**
  * TODO:

--- a/scripts/daemon.php
+++ b/scripts/daemon.php
@@ -38,7 +38,7 @@ foreach ($running as $page) {
 }
 
 //Regenerate the compiled headless script to account for changes
-$headless_runner = new \SiteMaster\Core\Auditor\HeadlessRunner();
+$headless_runner = new \SiteMaster\Core\Auditor\HeadlessRunner($daemon_name);
 $headless_runner->deleteCompiledScript();
 
 $total_incomplete = 0;

--- a/src/SiteMaster/Core/Auditor/HeadlessRunner.php
+++ b/src/SiteMaster/Core/Auditor/HeadlessRunner.php
@@ -8,9 +8,22 @@ use SiteMaster\Core\Util;
 
 class HeadlessRunner
 {
-    public function __construct()
+    protected $daemon_name;
+
+    /**
+     * HeadlessRunner constructor.
+     * 
+     * This will generate and scope headless js for each daemon instance
+     * 
+     * @param $daemon_name
+     * @throws \Exception
+     */
+    public function __construct($daemon_name = 'default')
     {
-        
+        if (!ctype_alnum($daemon_name)) {
+            throw new \Exception('Invalid daemon_name, it must be alphanumeric');
+        }
+        $this->daemon_name = $daemon_name;
     }
 
     /**
@@ -89,10 +102,10 @@ class HeadlessRunner
     public function getCompiledScriptLocation()
     {
         if (Config::get('ENVIRONMENT') == Config::ENVIRONMENT_TESTING) {
-            return Util::getRootDir() . '/tmp/sitemaster_headless_compiled_test.js';
+            return Util::getRootDir() . '/tmp/sitemaster_headless_'.$this->daemon_name.'_compiled_test.js';
         }
         
-        return Util::getRootDir() . '/tmp/sitemaster_headless_compiled.js';
+        return Util::getRootDir() . '/tmp/sitemaster_headless_'.$this->daemon_name.'_compiled.js';
     }
 
     /**

--- a/src/SiteMaster/Core/Auditor/HeadlessRunner.php
+++ b/src/SiteMaster/Core/Auditor/HeadlessRunner.php
@@ -74,7 +74,7 @@ class HeadlessRunner
         
         if (!$json) {
             //Log the error
-            Util::log(Logger::ERROR, 'Error parsing headless script', array(
+            Util::log(Logger::NOTICE, 'Error parsing headless script', array(
                 'result' => $result,
             ));
             

--- a/src/SiteMaster/Core/Auditor/Logger/Metrics.php
+++ b/src/SiteMaster/Core/Auditor/Logger/Metrics.php
@@ -59,7 +59,7 @@ class Metrics extends \Spider_LoggerAbstract
             if (isset($this->headless_results[$metric->getMachineName()])) {
                 $metric_phantom_results = $this->headless_results[$metric->getMachineName()];
                 if (isset($metricPhantomResults['exception'])) {
-                    Util::log(Logger::ERROR, 'headless metric exception', array(
+                    Util::log(Logger::NOTICE, 'headless metric exception', array(
                         'result' => $metricPhantomResults,
                     ));
                 }

--- a/src/SiteMaster/Core/Auditor/MetricInterface.php
+++ b/src/SiteMaster/Core/Auditor/MetricInterface.php
@@ -127,7 +127,7 @@ abstract class MetricInterface
             //Some sort of error occurred.  Mark this metric as incomplete
             $completed = false;
             Util::log(
-                \Monolog\Logger::ERROR,
+                \Monolog\Logger::NOTICE,
                 'Metric exception thrown for ' . $this->getMachineName(),
                 array(
                     'exception' => (string)$exception,

--- a/src/SiteMaster/Core/Auditor/Site/Page.php
+++ b/src/SiteMaster/Core/Auditor/Site/Page.php
@@ -303,7 +303,7 @@ class Page extends Record
      * @return bool false if the scan is not queued or ready to be scanned
      * @throws \Exception
      */
-    public function scan($daemon_name)
+    public function scan($daemon_name = 'default')
     {
         if ($this->status != self::STATUS_QUEUED) {
             //Looks like it has already been scanned (or has yet to be scheduled).  Don't continue.
@@ -514,7 +514,7 @@ class Page extends Record
      * @param string $daemon_name the name of the daemon performing the scan
      * @return null
      */
-    public function markAsRunning($daemon_name)
+    public function markAsRunning($daemon_name = 'default')
     {
         $scan = $this->getScan();
         if ($scan->status != Scan::STATUS_RUNNING) {

--- a/src/SiteMaster/Core/Auditor/Site/Page.php
+++ b/src/SiteMaster/Core/Auditor/Site/Page.php
@@ -339,7 +339,7 @@ class Page extends Record
         }
         
         //Run headless tests against the page (we need to do this here so we can pass the results to the metrics)
-        $headless_runner = new HeadlessRunner();
+        $headless_runner = new HeadlessRunner($this->daemon_name);
         $headless_results = $headless_runner->run($this->uri);
         
         $spider->addLogger(new Links($spider, $this));

--- a/src/SiteMaster/Core/Auditor/Site/Page.php
+++ b/src/SiteMaster/Core/Auditor/Site/Page.php
@@ -339,7 +339,7 @@ class Page extends Record
         }
         
         //Run headless tests against the page (we need to do this here so we can pass the results to the metrics)
-        $headless_runner = new HeadlessRunner($this->daemon_name);
+        $headless_runner = new HeadlessRunner($daemon_name);
         $headless_results = $headless_runner->run($this->uri);
         
         $spider->addLogger(new Links($spider, $this));

--- a/src/SiteMaster/Core/Auditor/Site/Page.php
+++ b/src/SiteMaster/Core/Auditor/Site/Page.php
@@ -45,6 +45,7 @@ class Page extends Record
     public $num_notices;           //INT, the number of notices found on this page
     public $found_with;            //ENUM('SITE_MAP', 'CRAWL') NOT NULL
     public $link_limit_hit;        //ENUM('NO', 'YES') NOT NULL
+    public $daemon_name;           //VARCHAR(256) - the name of the daemon that performed the scan
 
     const STATUS_CREATED  = 'CREATED';
     const STATUS_QUEUED   = 'QUEUED';
@@ -297,17 +298,19 @@ class Page extends Record
 
     /**
      * Scan this page
-     * 
+     *
+     * @param string $daemon_name the name of the daemon that is performing the scan
      * @return bool false if the scan is not queued or ready to be scanned
+     * @throws \Exception
      */
-    public function scan()
+    public function scan($daemon_name)
     {
         if ($this->status != self::STATUS_QUEUED) {
             //Looks like it has already been scanned (or has yet to be scheduled).  Don't continue.
             return false;
         }
 
-        $this->markAsRunning();
+        $this->markAsRunning($daemon_name);
         
         $scan = $this->getScan();
         $site = $this->getSite();
@@ -507,10 +510,11 @@ class Page extends Record
 
     /**
      * Mark this page as running
-     * 
+     *
+     * @param string $daemon_name the name of the daemon performing the scan
      * @return null
      */
-    public function markAsRunning()
+    public function markAsRunning($daemon_name)
     {
         $scan = $this->getScan();
         if ($scan->status != Scan::STATUS_RUNNING) {
@@ -519,6 +523,7 @@ class Page extends Record
         
         $this->start_time = Util::epochToDateTime();
         $this->status     = self::STATUS_RUNNING;
+        $this->daemon_name = $daemon_name;
         $this->save();
     }
 

--- a/src/SiteMaster/Core/Auditor/Site/Pages/Queued.php
+++ b/src/SiteMaster/Core/Auditor/Site/Pages/Queued.php
@@ -15,6 +15,14 @@ class Queued extends All
         if (isset($this->options['scans_id'])) {
             $where .= " AND scans_id = " . (int)$this->options['scans_id'];
         }
+
+        if (isset($this->options['not_in_scans']) && is_array($this->options['not_in_scans'])) {
+            $ids = array_map(function($val) {
+                //Cast to an int to prevent injection attacks
+                return (int)$val;
+            }, $this->options['not_in_scans']);
+            $where .= " AND scans_id NOT IN (" . explode(',', $ids) . ")";
+        }
         
         return $where;
     }

--- a/src/SiteMaster/Core/Auditor/Site/Pages/Queued.php
+++ b/src/SiteMaster/Core/Auditor/Site/Pages/Queued.php
@@ -16,11 +16,15 @@ class Queued extends All
             $where .= " AND scans_id = " . (int)$this->options['scans_id'];
         }
 
-        if (isset($this->options['not_in_scans']) && is_array($this->options['not_in_scans'])) {
+        if (isset($this->options['not_in_scans'])
+            && is_array($this->options['not_in_scans'])
+            && !empty($this->options['not_in_scans'])
+        ) {
             $ids = array_map(function($val) {
                 //Cast to an int to prevent injection attacks
                 return (int)$val;
             }, $this->options['not_in_scans']);
+            
             $where .= " AND scans_id NOT IN (" . implode(',', $ids) . ")";
         }
         

--- a/src/SiteMaster/Core/Auditor/Site/Pages/Queued.php
+++ b/src/SiteMaster/Core/Auditor/Site/Pages/Queued.php
@@ -21,7 +21,7 @@ class Queued extends All
                 //Cast to an int to prevent injection attacks
                 return (int)$val;
             }, $this->options['not_in_scans']);
-            $where .= " AND scans_id NOT IN (" . explode(',', $ids) . ")";
+            $where .= " AND scans_id NOT IN (" . implode(',', $ids) . ")";
         }
         
         return $where;

--- a/src/SiteMaster/Core/Auditor/Site/Pages/Running.php
+++ b/src/SiteMaster/Core/Auditor/Site/Pages/Running.php
@@ -5,7 +5,13 @@ class Running extends All
 {
     public function getWhere()
     {
-        return "WHERE status = 'RUNNING'";
+        $where = "WHERE status = 'RUNNING'";
+
+        if (isset($this->options['daemon_name'])) {
+            $where .= " AND daemon_name = '" . self::escapeString($this->options['daemon_name']). "'";
+        }
+        
+        return $where;
     }
 
     public function getLimit()

--- a/src/SiteMaster/Core/Plugin.php
+++ b/src/SiteMaster/Core/Plugin.php
@@ -251,6 +251,14 @@ class Plugin extends PluginInterface
                 return false;
             }
         }
+
+        if ($previousVersion <= 2017012601) {
+            $sql = file_get_contents(Util::getRootDir() . "/data/update-2017040701.sql");
+
+            if (!Util::execMultiQuery($sql, true)) {
+                return false;
+            }
+        }
         
         return true;
     }
@@ -276,7 +284,7 @@ class Plugin extends PluginInterface
      */
     public function getVersion()
     {
-        return 2017012601;
+        return 2017040701;
     }
 
     /**


### PR DESCRIPTION
Add support for multiple daemons, which should help to process the queue faster and handle more sites.

You can define additional daemons by giving giving them names such as `php scripts/daemon.php worker1` or `php scripts/daemon.php worker2`.

This will also track which pages are processed by which daemons to help avoid collisions and debug. It will also limit one daemon per site.

