### PR TITLE
Crawl links on single-page applications

### DIFF
--- a/data/compileHeadless.js.php
+++ b/data/compileHeadless.js.php
@@ -8,6 +8,11 @@ $headless_file = $this->getCompiledScriptLocation();
 //Make an array of metrics to use
 $metrics = [];
 
+$metrics[] = [
+    'file' => '../data/page_links.js',
+    'options' => [],
+];
+
 //Page analytics in core
 $metrics[] = [
 	'file' => '../data/page_analytics.js',

--- a/data/page_links.js
+++ b/data/page_links.js
@@ -1,0 +1,33 @@
+
+/**
+ * Must define an evaluate function that is compatible with nightmare.use()
+ *
+ * This essentially defines a nightmare.js plugin which should run the tests and return a result object (see code for an example of the result object)
+ *
+ * @param metric_name the metric's machine name will be passed so that the results object can set the name correctly
+ * @returns {Function}
+ */
+exports.evaluate = function(options) {
+	//using the given nightmare instance
+	return function(nightmare) {
+		nightmare.evaluate(function(options) {
+			//Now we need to return a result objec
+			let links = [];
+
+			//Loop though all elements on the page
+			let all = document.getElementsByTagName("a");
+			for (let i = 0; i < all.length; i++) {
+				// Record the element name
+				links.push(all[i].href);
+			}
+
+			return {
+				//The results are stored in the 'results' property
+				results: links,
+
+				//The metric name is stored in the 'name' property with the same value used in Metric::getMachineName()
+				'name': 'core-links'
+			};
+		}, options);
+	};
+};

--- a/src/SiteMaster/Core/Auditor/Logger/Scheduler.php
+++ b/src/SiteMaster/Core/Auditor/Logger/Scheduler.php
@@ -3,6 +3,7 @@ namespace SiteMaster\Core\Auditor\Logger;
 
 use DOMXPath;
 use Monolog\Logger;
+use SiteMaster\Core\Auditor\Spider;
 use SiteMaster\Core\Config;
 use SiteMaster\Core\Registry\Registry;
 use SiteMaster\Core\Registry\Site;
@@ -27,7 +28,7 @@ class Scheduler extends \Spider_LoggerAbstract
      */
     protected $site = false;
 
-    function __construct(\Spider $spider, Scan $scan, Site $site)
+    function __construct(Spider $spider, Scan $scan, Site $site)
     {
         $this->spider = $spider;
         $this->scan = $scan;

--- a/src/SiteMaster/Core/Auditor/Spider.php
+++ b/src/SiteMaster/Core/Auditor/Spider.php
@@ -1,0 +1,106 @@
+<?php
+namespace SiteMaster\Core\Auditor;
+
+use DOMXPath;
+use Spider_Filter_Anchor;
+use Spider_Filter_EffectiveURI;
+use Spider_Filter_Empty;
+use Spider_Filter_External;
+use Spider_Filter_JavaScript;
+use Spider_Filter_Mailto;
+use Spider_Filter_RobotsTxt;
+use Spider_UriIterator;
+
+/**
+ * We are overriding the Spider class so that we can augment the functionality with data that is rendered by the DOM
+ * 
+ * Specifically, the php DOM implementation does not render JS, so in order to handle single page applications and dynamic content, we are using URIs as provided by an external interface.
+ * 
+ * We still want the Spider to filter the URIs for different circumstances.
+ * 
+ * Class Spider
+ * @package SiteMaster\Core\Auditor
+ */
+class Spider extends \Spider
+{
+    /**
+     * @var array $uris
+     */
+    protected static $uris = [];
+
+    /**
+     * Set the URIs to use internally
+     * 
+     * @param array $uris
+     */
+    public static function setURIs(array $uris)
+    {
+        self::$uris = $uris;
+    }
+    
+    /**
+     * Returns all valid uris for a page
+     * 
+     * Overriden so that self::$uris is used instead of parsing the DOM
+     *
+     * @param string   $baseUri    - the base uri for the page (NOT the site base)
+     * @param string   $currentUri - the uri of the document
+     * @param DOMXPath $xpath      - the xpath for the document
+     *
+     * @return Spider_UriIterator - a list of uris
+     */
+    public static function getUris($baseUri, $currentUri, DOMXPath $xpath)
+    {
+        return new Spider_UriIterator(self::$uris);
+    }
+
+    /**
+     * Get all crawlable uris for a page
+     * crawlable uris are URIs that that the spider can crawl
+     *
+     * This removes anchors, empty uris, javascipr and mailto calls, external uris, and uris that return a 404
+     *
+     * It will also get the effective URIs for a uri (the final uri if it redirects)
+     *
+     * @param          $startUri   - the base uri for the site
+     * @param string   $baseUri    - the base uri for the page
+     * @param string   $currentUri - the current uri to get URIs from
+     * @param DOMXPath $xpath      - the DOMXPath object for the current uri
+     *
+     * @return Spider_UriIterator - a list of uris
+     */
+    public function getCrawlableUris($startUri, $baseUri, $currentUri, DOMXPath $xpath)
+    {
+        $uris = self::getUris($baseUri, $currentUri, $xpath);
+
+        //remove anchors
+        $uris = new Spider_Filter_Anchor($uris);
+
+        //remove empty uris
+        $uris = new Spider_Filter_Empty($uris);
+
+        //remove javascript
+        $uris = new Spider_Filter_JavaScript($uris);
+
+        //remove mailto links
+        $uris = new Spider_Filter_Mailto($uris);
+
+        //Filter external links out. (do now to reduce the number of HTTP requests that we have to make)
+        $uris = new Spider_Filter_External($uris, $startUri);
+
+        if ($this->options['use_effective_uris']) {
+            //Get the effective URIs
+            $uris = new Spider_Filter_EffectiveURI($uris, $this->options['curl_options']);
+
+            //Filter external links again as they may have changed due to the effectiveURI filter.
+            $uris = new Spider_Filter_External($uris, $startUri);
+        }
+
+        if ($this->options['respect_robots_txt']) {
+            //Filter out pages that are disallowed by robots.txt
+            $uris = new Spider_Filter_RobotsTxt($uris, $this->options);
+        }
+
+        return $uris;
+    }
+}

--- a/tests/SiteMaster/Core/Auditor/HeadlessRunnerTest.php
+++ b/tests/SiteMaster/Core/Auditor/HeadlessRunnerTest.php
@@ -16,5 +16,7 @@ class HeadlessRunnerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertArrayHasKey('page_title', $results['example']);
         $this->assertArrayHasKey('core-page-analytics', $results);
+        $this->assertArrayHasKey('core-links', $results);
+        $this->assertTrue(in_array('http://example.org/generated-by-js', $results['core-links']), 'JS generated links should be included');
     }
 }

--- a/tests/SiteMaster/Core/Auditor/Logger/LinksDBTest.php
+++ b/tests/SiteMaster/Core/Auditor/Logger/LinksDBTest.php
@@ -26,20 +26,28 @@ class LinksDBTest extends DBTestCase
         //Get a test site
         $site = Site::getByBaseURL($base_uri);
 
-        //Set up a spider that needs to be sent to the logger
-        $parser = new HTML5();
-        $spider = new \Spider(new \Spider_Downloader(), $parser, array(
-                'respect_robots_txt'=>false,
-                'use_effective_uris' => false)
-        );
         $scan = Scan::createNewScan($site);
-        
+
         //Create a new page scan for the base url
         $scan->scheduleScan();
 
         //Get that page scan
         $page = Page::getByScanIDAndURI($scan->id, $base_uri);
 
+        //Set up a spider that needs to be sent to the logger
+        $parser = new HTML5();
+        $spider = new Spider(new Downloader\HTMLOnly($site, $page, $scan), $parser, array(
+                'respect_robots_txt'=>false,
+                'use_effective_uris' => false)
+        );
+        
+        Spider::setURIs([
+            'http://unlcms.unl.edu/university-communications/sitemaster/example-redirect-301',
+            'http://unlcms.unl.edu/university-communications/sitemaster/example-404',
+            'http://unlcms.unl.edu/university-communications/sitemaster/example-404',
+            'http://unlcms.unl.edu/university-communications/sitemaster/',
+        ]);
+        
         //Set up the logger to test
         $logger = new Logger\Links($spider, $page);
 

--- a/tests/SiteMaster/Core/Auditor/Logger/SchedulerDBTest.php
+++ b/tests/SiteMaster/Core/Auditor/Logger/SchedulerDBTest.php
@@ -22,10 +22,18 @@ class SchedulerDBTest extends DBTestCase
         
         //Set up a spider that needs to be sent to the logger
         $parser = new HTML5();
-        $spider = new \Spider(new \Spider_Downloader(), $parser, array(
+        $spider = new Spider(new \Spider_Downloader(), $parser, array(
             'respect_robots_txt'=>false,
             'use_effective_uris' => false)
         );
+        
+        //Simulate the headless result of links
+        Spider::setURIs([
+            'http://www.test.com/page2.html',
+            'https://www.test.com/page2.html',
+            'http://www.test.com/test/page2.html',
+        ]);
+        
         $scan = Scan::createNewScan($site);
         
         //Set up the logger to test


### PR DESCRIPTION
Instead of parsing the RAW html in php, grab all of the links as found by the headless browser, which will execute JS. Single page applications will often inject the HTML content (including links) after the page initially loads.

This also fixes some tests and adds a test for this functionality.

We will eventually retire the PHP parsing layer in favor of purely headless based tests.