### PR TITLE
Fix bug where spelling errors were not being added to global override list

### DIFF
--- a/src/SiteMaster/Core/Auditor/Override.php
+++ b/src/SiteMaster/Core/Auditor/Override.php
@@ -115,7 +115,7 @@ class Override extends Record
      */
     public static function getGlobalOverride($marks_id, $value_found)
     {
-        return self::getByAnyField(__CLASS__, 'value_found', $value_found, 'marks_id = ' . (int) $marks_id);
+        return self::getByAnyField(__CLASS__, 'value_found', $value_found, 'marks_id = ' . (int) $marks_id . ' AND scope = "GLOBAL"');
     }
 
     /**


### PR DESCRIPTION
Add a scope condition, otherwise this will return page overrides too. Because overrides are usually added as an element or page override first, this was preventing them from ever becoming global overrides.