### PR TITLE
Add CSRF form info for updating pending roles

### DIFF
--- a/www/templates/html/SiteMaster/Core/Registry/Site/MembersForm.tpl.php
+++ b/www/templates/html/SiteMaster/Core/Registry/Site/MembersForm.tpl.php
@@ -61,7 +61,8 @@ if ($can_edit) {
         if (!$context->pending->count()) {
             echo "There are no pending roles.";
         } else {
-            ?>
+            $csrf_helper->insertToken();
+        ?>
             <ul>
                 <?php
                 foreach ($context->pending as $member_role) {


### PR DESCRIPTION
I checked the forms listed in issue https://github.com/UNLSiteMaster/site_master/issues/154  all have the `$csrf_helper->insertToken()`.  If those forms are still an issue or are occasionally we might want to pass in the $lockTo parameter if the form endpoint can at times not match the computed lockTo. 