### PR TITLE
Override Util::getHTTPInfo UserAgent for twitter.com

### DIFF
--- a/.idea/site_master.iml
+++ b/.idea/site_master.iml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/vendor/unl_submodules" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/vendor/unl_submodules/RegExpRouter/src" isTestSource="false" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>
-

--- a/src/SiteMaster/Core/Util.php
+++ b/src/SiteMaster/Core/Util.php
@@ -10,6 +10,9 @@ class Util
 {
     protected static $db = false;
 
+    const DEFAULT_USER_AGENT = 'UNL_SITEMASTER/1.0';
+    const CHROME_44_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.157 Safari/537.36';
+
     public static function setDB($host, $user, $password, $database)
     {
         self::$db = new \mysqli($host, $user, $password, $database);
@@ -208,6 +211,17 @@ class Util
         return $base_url;
     }
 
+    public static function overrideUserAgent($url, &$options) {
+        $urlParts = parse_url($url);
+        if (!isset($urlParts['host'])) {
+            return;
+        }
+        switch(strtolower($urlParts['host'])) {
+            case 'twitter.com':
+                $options[CURLOPT_USERAGENT] = self::CHROME_44_USER_AGENT;
+        }
+    }
+
     /**
      * @param $url
      * @param array $options array of CURL options used in curl_setop_array
@@ -216,6 +230,8 @@ class Util
      */
     public static function getHTTPInfo($url, $options = array())
     {
+        $urlInfo = parse_url($url);
+
         $curl = curl_init($url);
         
         $default_options = array(
@@ -224,11 +240,13 @@ class Util
             CURLOPT_MAXREDIRS      => 5,
             CURLOPT_TIMEOUT        => 30,
             CURLOPT_FOLLOWLOCATION => false,
-            CURLOPT_USERAGENT      => 'UNL_SITEMASTER/1.0',
+            CURLOPT_USERAGENT      => self::DEFAULT_USER_AGENT,
             CURLOPT_FILE           => fopen('/dev/null', 'w+')
         );
         
         $options = $options + $default_options;
+
+        self::overrideUserAgent($url, $options);
 
         curl_setopt_array($curl, $options);
         

--- a/src/SiteMaster/Core/Util.php
+++ b/src/SiteMaster/Core/Util.php
@@ -219,6 +219,7 @@ class Util
         switch(strtolower($urlParts['host'])) {
             case 'twitter.com':
                 $options[CURLOPT_USERAGENT] = self::CHROME_44_USER_AGENT;
+                break;
         }
     }
 


### PR DESCRIPTION
Curl requests for twitter.com links are returning 400 Bad Request errors due to Twitter restrictions on valid user agents.

`curl -X GET "https://twitter.com/UNLMHDI/status/1204508333949865984?s=20"`

**This browser is no longer supported.** 
Please switch to a supported browser to continue using twitter.com. You can see a list of supported browsers in our Help Center. https://help.twitter.com/using-twitter/twitter-supported-browsers

This fix will force the User Agent to a Chrome 44 definition for curl requests to twitter.com to meet the Twitter user agent restriction.
