### PR TITLE
Added Query type for URL contains

### DIFF
--- a/src/SiteMaster/Core/Registry/Query.php
+++ b/src/SiteMaster/Core/Registry/Query.php
@@ -13,7 +13,6 @@ class Query extends \IteratorIterator
     const QUERY_TYPE_ALL  = 1;
     const QUERY_TYPE_URL  = 2;
     const QUERY_TYPE_USER = 3;
-    const QUERY_TYPE_URL_CONTAINS = 4;
 
     function __construct($options = array())
     {
@@ -54,10 +53,9 @@ class Query extends \IteratorIterator
                 return 'getByUser';
             case self::QUERY_TYPE_ALL:
                 return 'getByALL';
-            case self::QUERY_TYPE_URL_CONTAINS:
-                return 'getByURLContains';
             default:
-                return 'getByURL';
+                return 'getByURLContains';
+                // return 'getByURL';
         }
     }
 
@@ -71,9 +69,6 @@ class Query extends \IteratorIterator
      */
     public function getQueryType($query)
     {
-        if(filter_var(substr($query, 0, -1), FILTER_VALIDATE_URL) == substr($query, 0, -1) && substr($query, -1) == '*'){
-            return self::QUERY_TYPE_URL_CONTAINS;
-        }
         //Determine the type of query and get the sites associated with it.
         switch ($query) {
             case filter_var($query, FILTER_VALIDATE_URL): //Get a site and it's parents.

--- a/src/SiteMaster/Core/Registry/Query.php
+++ b/src/SiteMaster/Core/Registry/Query.php
@@ -74,7 +74,10 @@ class Query extends \IteratorIterator
     {
 
         // will be a url with a * at the end
-        if(filter_var(substr($query, 0 , -1), FILTER_VALIDATE_URL) == substr($query, 0, -1) && substr($query, -1) == '*' && strlen($query) != 1){
+        if (filter_var(substr($query, 0 , -1), FILTER_VALIDATE_URL) == substr($query, 0, -1) 
+            && substr($query, -1) == '*' 
+            && strlen($query) != 1) {
+        
             return self::QUERY_TYPE_URL_CONTAINS;
         }
 
@@ -170,10 +173,11 @@ class Query extends \IteratorIterator
         $queried_sites = $this->registry->getSitesContaining($queryStripped);
 
         // loops through those sites and checks for aliases
-        foreach($queried_sites as $site){
+        foreach ($queried_sites as $site) {
             
             //check for aliases
-            if (isset(Registry::$aliases[$site->base_url]) && $alias = Site::getByBaseURL(Registry::$aliases[$site->base_url])) {
+            if (isset(Registry::$aliases[$site->base_url]) 
+                && $alias = Site::getByBaseURL(Registry::$aliases[$site->base_url])) {
                 $site = $alias;
             }
             $sites[] = $site;

--- a/src/SiteMaster/Core/Registry/Query.php
+++ b/src/SiteMaster/Core/Registry/Query.php
@@ -72,7 +72,7 @@ class Query extends \IteratorIterator
     public function getQueryType($query)
     {
         // will be a url with a * at the end
-        if(filter_var(substr($query, 0 , -1)) == substr($query, 0, -1) && substr($query, -1) == '*'){
+        if(filter_var(substr($query, 0 , -1), FILTER_VALIDATE_URL) == substr($query, 0, -1) && substr($query, -1) == '*'){
             return self::QUERY_TYPE_URL_CONTAINS;
         }
 

--- a/src/SiteMaster/Core/Registry/Query.php
+++ b/src/SiteMaster/Core/Registry/Query.php
@@ -54,7 +54,8 @@ class Query extends \IteratorIterator
             case self::QUERY_TYPE_ALL:
                 return 'getByALL';
             default:
-                return 'getByURL';
+                return 'getByURLContains';
+                // return 'getByURL';
         }
     }
 
@@ -142,4 +143,32 @@ class Query extends \IteratorIterator
         
         return $sites;
     }
+
+    /**
+     * Get all sites containing a URL
+     * 
+     * @param $query
+     * @return array
+     */
+    public function getByURLContains($query)
+    {
+        $sites = array();
+        
+        if (!$site = $this->registry->getSitesContaining($query)) {
+            return $sites;
+        }
+        
+        do {
+            //Handle aliases
+            if (isset(Registry::$aliases[$site->base_url])
+                && $alias = Site::getByBaseURL(Registry::$aliases[$site->base_url])) {
+                $site = $alias;
+            }
+            
+            $sites[] = $site;
+        } while ($site = $site->getParentSite());
+        
+        return $sites;
+    }
+
 }

--- a/src/SiteMaster/Core/Registry/Query.php
+++ b/src/SiteMaster/Core/Registry/Query.php
@@ -13,6 +13,7 @@ class Query extends \IteratorIterator
     const QUERY_TYPE_ALL  = 1;
     const QUERY_TYPE_URL  = 2;
     const QUERY_TYPE_USER = 3;
+    const QUERY_TYPE_URL_CONTAINS = 4;
 
     function __construct($options = array())
     {
@@ -53,9 +54,10 @@ class Query extends \IteratorIterator
                 return 'getByUser';
             case self::QUERY_TYPE_ALL:
                 return 'getByALL';
+            case self::QUERY_TYPE_USER:
+                return 'getByURL';
             default:
                 return 'getByURLContains';
-                // return 'getByURL';
         }
     }
 
@@ -69,6 +71,11 @@ class Query extends \IteratorIterator
      */
     public function getQueryType($query)
     {
+        // will be a url with a * at the end
+        if(filter_var(substr($query, 0 , -1)) == substr($query, 0, -1) && substr($query, -1) == '*'){
+            return self::QUERY_TYPE_URL_CONTAINS;
+        }
+
         //Determine the type of query and get the sites associated with it.
         switch ($query) {
             case filter_var($query, FILTER_VALIDATE_URL): //Get a site and it's parents.
@@ -153,8 +160,11 @@ class Query extends \IteratorIterator
     public function getByURLContains($query)
     {
         $sites = array();
+
+        // removes * from end
+        $queryStripped = substr($query, 0, -1);
         
-        if (!$site = $this->registry->getSitesContaining($query)) {
+        if (!$site = $this->registry->getSitesContaining($queryStripped)) {
             return $sites;
         }
         

--- a/src/SiteMaster/Core/Registry/Query.php
+++ b/src/SiteMaster/Core/Registry/Query.php
@@ -13,6 +13,7 @@ class Query extends \IteratorIterator
     const QUERY_TYPE_ALL  = 1;
     const QUERY_TYPE_URL  = 2;
     const QUERY_TYPE_USER = 3;
+    const QUERY_TYPE_URL_CONTAINS = 4;
 
     function __construct($options = array())
     {
@@ -53,9 +54,10 @@ class Query extends \IteratorIterator
                 return 'getByUser';
             case self::QUERY_TYPE_ALL:
                 return 'getByALL';
-            default:
+            case self::QUERY_TYPE_URL_CONTAINS:
                 return 'getByURLContains';
-                // return 'getByURL';
+            default:
+                return 'getByURL';
         }
     }
 
@@ -69,6 +71,9 @@ class Query extends \IteratorIterator
      */
     public function getQueryType($query)
     {
+        if(filter_var(substr($query, 0, -1), FILTER_VALIDATE_URL) == substr($query, 0, -1) && substr($query, -1) == '*'){
+            return self::QUERY_TYPE_URL_CONTAINS;
+        }
         //Determine the type of query and get the sites associated with it.
         switch ($query) {
             case filter_var($query, FILTER_VALIDATE_URL): //Get a site and it's parents.

--- a/src/SiteMaster/Core/Registry/Query.php
+++ b/src/SiteMaster/Core/Registry/Query.php
@@ -54,7 +54,7 @@ class Query extends \IteratorIterator
                 return 'getByUser';
             case self::QUERY_TYPE_ALL:
                 return 'getByALL';
-            case self::QUERY_TYPE_USER:
+            case self::QUERY_TYPE_URL:
                 return 'getByURL';
             default:
                 return 'getByURLContains';

--- a/src/SiteMaster/Core/Registry/Query.php
+++ b/src/SiteMaster/Core/Registry/Query.php
@@ -37,7 +37,7 @@ class Query extends \IteratorIterator
             //Make sure it is traversable
             $result = new \ArrayIterator($result);
         }
-        
+
         return new Result(array('result' => $result));
     }
 
@@ -49,6 +49,7 @@ class Query extends \IteratorIterator
      */
     public function getQueryFunction($type)
     {
+
         switch ($type) {
             case self::QUERY_TYPE_USER:
                 return 'getByUser';
@@ -71,8 +72,9 @@ class Query extends \IteratorIterator
      */
     public function getQueryType($query)
     {
+
         // will be a url with a * at the end
-        if(filter_var(substr($query, 0 , -1), FILTER_VALIDATE_URL) == substr($query, 0, -1) && substr($query, -1) == '*'){
+        if(filter_var(substr($query, 0 , -1), FILTER_VALIDATE_URL) == substr($query, 0, -1) && substr($query, -1) == '*' && strlen($query) != 1){
             return self::QUERY_TYPE_URL_CONTAINS;
         }
 
@@ -133,11 +135,11 @@ class Query extends \IteratorIterator
     public function getByURL($query)
     {
         $sites = array();
-        
+
         if (!$site = $this->registry->getClosestSite($query)) {
             return $sites;
         }
-        
+
         do {
             //Handle aliases
             if (isset(Registry::$aliases[$site->base_url])
@@ -147,38 +149,36 @@ class Query extends \IteratorIterator
             
             $sites[] = $site;
         } while ($site = $site->getParentSite());
-        
+
         return $sites;
     }
 
     /**
-     * Get all sites containing a URL
-     * 
-     * @param $query
-     * @return array
-     */
+    * Get all sites containing a URL
+    * 
+    * @param $query
+    * @return array
+    */
     public function getByURLContains($query)
     {
         $sites = array();
 
-        // removes * from end
+        // removed the * at the end
         $queryStripped = substr($query, 0, -1);
         
-        if (!$site = $this->registry->getSitesContaining($queryStripped)) {
-            return $sites;
-        }
-        
-        do {
-            //Handle aliases
-            if (isset(Registry::$aliases[$site->base_url])
-                && $alias = Site::getByBaseURL(Registry::$aliases[$site->base_url])) {
+        // gets all the sites that start with that URI
+        $queried_sites = $this->registry->getSitesContaining($queryStripped);
+
+        // loops through those sites and checks for aliases
+        foreach($queried_sites as $site){
+            
+            //check for aliases
+            if (isset(Registry::$aliases[$site->base_url]) && $alias = Site::getByBaseURL(Registry::$aliases[$site->base_url])) {
                 $site = $alias;
             }
-            
             $sites[] = $site;
-        } while ($site = $site->getParentSite());
-        
+        }
+
         return $sites;
     }
-
 }

--- a/src/SiteMaster/Core/Registry/Registry.php
+++ b/src/SiteMaster/Core/Registry/Registry.php
@@ -259,7 +259,7 @@ class Registry
         // we get all the ids
         // we can not get the site since the $stmt connection is still open
         $fetched_ids = array();
-        while($stmt->fetch()){
+        while ($stmt->fetch()) {
             if (is_null($id)) {
                 continue;
             }
@@ -271,9 +271,9 @@ class Registry
 
         // we do this loop to get the site and validate it
         $fetched_sites = array();
-        foreach($fetched_ids as $id){
+        foreach ($fetched_ids as $id) {
             $site = Site::getByID($id);
-            if($site === false){
+            if ($site === false) {
                 continue;
             }
             $fetched_sites[] = $site;

--- a/tests/SiteMaster/Core/Registry/QueryDBTest.php
+++ b/tests/SiteMaster/Core/Registry/QueryDBTest.php
@@ -70,6 +70,29 @@ class QueryDBTest extends DBTestCase
     /**
      * @test
      */
+    public function getByURLContains()
+    {
+        $this->setUpDB();
+
+        $query = new Query();
+        $result = $query->query('http://www.test.com/*');
+        $sites = array();
+
+        foreach ($result as $site) {
+            $sites[] = $site->base_url;
+        }
+
+        $expected = array(
+            'http://www.test.com/',
+            'http://www.test.com/test/',
+        );
+
+        $this->assertEquals($expected, $sites, 'This should return two sites, with the matching site first');
+    }
+
+    /**
+     * @test
+     */
     public function getByAll()
     {
         $this->setUpDB();

--- a/tests/SiteMaster/Core/Registry/QueryTest.php
+++ b/tests/SiteMaster/Core/Registry/QueryTest.php
@@ -9,6 +9,11 @@ class QueryTest extends \PHPUnit\Framework\TestCase
     public function getQueryType()
     {
         $query = new Query();
+
+        $this->assertEquals(Query::QUERY_TYPE_URL_CONTAINS, $query->getQueryType('http://www.domain.com/*'));
+        $this->assertEquals(Query::QUERY_TYPE_URL_CONTAINS, $query->getQueryType('http://www.domain.com/test/*'));
+        $this->assertEquals(Query::QUERY_TYPE_URL_CONTAINS, $query->getQueryType('http://www.domain.com/test/test.php?query#fragment*'));
+        $this->assertEquals(Query::QUERY_TYPE_URL_CONTAINS, $query->getQueryType('http://www.domain.com*'));
         
         $this->assertEquals(Query::QUERY_TYPE_URL, $query->getQueryType('http://www.domain.com/'));
         $this->assertEquals(Query::QUERY_TYPE_URL, $query->getQueryType('http://www.domain.com/test/'));


### PR DESCRIPTION
Bob had asked to change the search from an exact match to a 'contains' search. I then added a query type that consists of a URL with a * at the end to do a contains type search. 

An example is 'https://www.test.com*' would find [ https://www.test.com, https://www.test.com/about, https://www.test.com/home, etc. ] 