### PR TITLE
Added allow custom overrides for link errors

### DIFF
--- a/plugins/metric_links/src/Metric.php
+++ b/plugins/metric_links/src/Metric.php
@@ -90,6 +90,16 @@ class Metric extends MetricInterface
     }
 
     /**
+     *  This will allow custom overrides manually defined in overrides table to be honored.
+     *
+     * @return bool
+     */
+    public function allowCustomOverridingErrors()
+    {
+        return true;
+    }
+
+    /**
      * Get the human readable name of this metric
      *
      * @return string The human readable name of the metric


### PR DESCRIPTION
Had issues with websites blocking our user agent and returning 4040 which can not be overridden. These pages are normally 200 without the user agent issues