### PR TITLE
Added more logic to catch long redirect chains

### DIFF
--- a/plugins/metric_links/src/Metric.php
+++ b/plugins/metric_links/src/Metric.php
@@ -205,7 +205,8 @@ class Metric extends MetricInterface
             }
 
             // If we get an error after the redirect
-            if ($link->isRedirect() && $this->isFinalError($link)) {
+            // If the final status code is a redirect that means the redirect chain was too long and we don't care about it anymore just give them a notice
+            if ($link->isRedirect() && !$link->isFinalRedirect() && $this->isFinalError($link)) {
                 $machine_name = $this->getMachineNameForFinalStatus($link);
                 $message      = $this->getStatusMessage($machine_name);
                 $help_text    = $this->getStatusHelpText($machine_name);

--- a/src/SiteMaster/Core/Auditor/Site/Page/Link.php
+++ b/src/SiteMaster/Core/Auditor/Site/Page/Link.php
@@ -166,6 +166,20 @@ class Link extends Record
     }
 
     /**
+     * Determine if this link's final was a redirect
+     * 
+     * @return bool
+     */
+    public function isFinalRedirect()
+    {
+        if (in_array($this->final_status_code, array(301, 302))) {
+            return true;
+        }
+        
+        return false;
+    }
+
+    /**
      * Determine if this link resulted in a CURL error
      * 
      * @return bool


### PR DESCRIPTION
We were getting `link_http_code_after_redirect_301` marks which just means the redirect chains were too long and we should just mark them as notices and move on