### PR TITLE
Add recommended attribute to the url for form action

### DIFF
--- a/src/SiteMaster/Core/Registry/Site/AddSiteForm.php
+++ b/src/SiteMaster/Core/Registry/Site/AddSiteForm.php
@@ -119,6 +119,10 @@ class AddSiteForm extends AbstractPostHandler implements ViewableInterface
 
     public function getEditURL()
     {
+        if (isset($_GET['recommended']) && !empty($_GET['recommended'])) {
+            return $this->getURL() . "?recommended=" . $_GET['recommended'];
+        }
+
         return $this->getURL();
     }
 }


### PR DESCRIPTION
When you click the QA Test in the UNL footer it will take you to the "Quality Assurance" page. On that page if the site does not exist it will give you a link to make it labeled by "Register the site now". Clicking that link will take you to the add site form but the URL does not match the form action. That causes the csrf token to become invalidated when you submit the form